### PR TITLE
Instance server event

### DIFF
--- a/resource/areas.json
+++ b/resource/areas.json
@@ -2001,391 +2001,405 @@
   "vaal": {
     "Strange Sinkhole": {
       "bosses": [
-        [
-          "Mother of the Hive"
-        ]
+        {
+          "name": "Mother of the Hive"
+        }
       ]
     },
     "Concealed Cavity": {
       "bosses": [
-        [
-          "The All-seeing Eye"
-        ]
+        {
+          "name": "The All-seeing Eye"
+        }
       ]
     },
     "Sunken Shingle": {
       "bosses": [
-        [
-          "Perquil the Lucky"
-        ]
+        {
+          "name": "Perquil the Lucky"
+        }
       ]
     },
     "Clouded Ridge": {
       "bosses": [
-        [
-          "Konu, Maker of Wind"
-        ]
+        {
+          "name": "Konu, Maker of Wind"
+        }
       ]
     },
     "Forgotten Oubliette": {
       "bosses": [
-        [
-          "Coniraya, Shadow of Malice"
-        ]
+        {
+          "name": "Coniraya, Shadow of Malice"
+        }
       ]
     },
     "Remote Gulch": {
       "bosses": [
-        [
-          "Sheaq, Maker of Floods"
-        ]
+        {
+          "name": "Sheaq, Maker of Floods"
+        }
       ]
     },
     "Narrow Ravine": {
       "bosses": [
-        [
-          "Kamaq, Soilmaker"
-        ]
+        {
+          "name": "Kamaq, Soilmaker"
+        }
       ]
     },
     "Mystical Clearing": {
       "bosses": [
-        [
-          "Simi, the Nature Touched"
-        ]
+        {
+          "name": "Simi, the Nature Touched"
+        }
       ]
     },
     "Covered-up Hollow": {
       "bosses": [
-        [
-          "Cintiq, the Inescapable"
-        ]
+        {
+          "name": "Cintiq, the Inescapable"
+        }
       ]
     },
     "Hidden Patch": {
       "bosses": [
-        [
-          "Thornrunner"
-        ]
+        {
+          "name": "Thornrunner"
+        }
       ]
     },
     "Entombed Alcove": {
       "bosses": [
-        [
-          "Shrapnelbearer"
-        ]
+        {
+          "name": "Shrapnelbearer"
+        }
       ]
     },
     "Secret Laboratory": {
       "bosses": [
-        [
-          "Atziri's Pride"
-        ]
+        {
+          "name": "Atziri's Pride"
+        }
       ]
     },
     "Secluded Copse": {
       "bosses": [
-        [
-          "Kutec, Vaal Fleshsmith"
-        ]
+        {
+          "name": "Kutec, Vaal Fleshsmith"
+        }
       ]
     },
     "Forbidden Chamber": {
       "bosses": [
-        [
-          "Haviri, Vaal Metalsmith"
-        ]
+        {
+          "name": "Haviri, Vaal Metalsmith"
+        }
       ]
     },
     "Quarantined Quarters": {
       "bosses": [
-        [
-          "The Sunburst Queen"
-        ]
+        {
+          "name": "The Sunburst Queen"
+        }
       ]
     },
     "Disused Furnace": {
       "bosses": [
-        [
-          "Curator Miem"
-        ]
+        {
+          "name": "Curator Miem"
+        }
       ]
     },
     "Blind Alley": {
       "bosses": [
-        [
-          "M'gaska, the Living Pyre"
-        ]
+        {
+          "name": "M'gaska, the Living Pyre"
+        }
       ]
     },
     "Entombed Chamber": {
       "bosses": [
-        [
-          "Ossecati, Boneshaper"
-        ]
+        {
+          "name": "Ossecati, Boneshaper"
+        }
       ]
     },
     "Sacred Chambers": {
       "bosses": [
-        [
-          "Shadow of Vengeance"
-        ]
+        {
+          "name": "Shadow of Vengeance"
+        }
       ]
     },
     "Stagnant Canal": {
       "bosses": [
-        [
-          "Wiraqucha, Ancient Guardian"
-        ]
+        {
+          "name": "Wiraqucha, Ancient Guardian"
+        }
       ]
     },
     "Walled-off Ducts": {
       "bosses": [
-        [
-          "Cava, Artist of Pain"
-        ]
+        {
+          "name": "Cava, Artist of Pain"
+        }
       ]
     },
     "Neglected Cellar": {
       "bosses": [
-        [
-          "Rima, Deep Temptress"
-        ]
+        {
+          "name": "Rima, Deep Temptress"
+        }
       ]
     },
     "Arcane Chambers": {
       "bosses": [
-        [
-          "Beheader Ataguchu"
-        ]
+        {
+          "name": "Beheader Ataguchu"
+        }
       ]
     },
     "Inner Grounds": {
       "bosses": [
-        [
-          "Inti of the Blood Moon"
-        ]
+        {
+          "name": "Inti of the Blood Moon"
+        }
       ]
     },
     "Sealed Corridors": {
       "bosses": [
-        [
-          "Wiraq, the Impaler"
-        ]
+        {
+          "name": "Wiraq, the Impaler"
+        }
       ]
     },
     "Restricted Gallery": {
       "bosses": [
-        [
-          "Ch'aska, Maker of Rain"
-        ]
+        {
+          "name": "Ch'aska, Maker of Rain"
+        }
       ]
     },
     "Forgotten Conduit": {
       "bosses": [
-        [
-          "Torrent of Fear"
-        ]
+        {
+          "name": "Torrent of Fear"
+        }
       ]
     },
     "Ancient Catacomb": {
       "bosses": [
-        [
-          "Commander of Flesh"
-        ]
+        {
+          "name": "Commander of Flesh"
+        }
       ]
     },
     "Haunted Mineshaft": {
       "bosses": [
-        [
-          "Calxipher"
-        ]
+        {
+          "name": "Calxipher"
+        }
       ]
     },
     "Abandoned Dam": {
       "bosses": [
-        [
-          "Quetzerxi"
-        ]
+        {
+          "name": "Quetzerxi"
+        }
       ]
     },
     "Desolate Track": {
       "bosses": [
-        [
-          "Quetzerxi"
-        ]
+        {
+          "name": "Quetzerxi"
+        }
       ]
     },
     "Reclaimed Barracks": {
       "bosses": [
-        [
-          "Huitepa the Blind"
-        ]
+        {
+          "name": "Huitepa the Blind"
+        }
       ]
     },
     "Sealed Basement": {
       "bosses": [
-        [
-          "Guraq, Daylight's Blade"
-        ]
+        {
+          "name": "Guraq, Daylight's Blade"
+        }
       ]
     },
     "Secluded Canal": {
       "bosses": [
-        [
-          "Xuatl, Cutting Wind"
-        ]
+        {
+          "name": "Xuatl, Cutting Wind"
+        }
       ]
     },
     "Forbidden Archives": {
       "bosses": [
-        [
-          "Exartze, the Woven Stone"
-        ]
+        {
+          "name": "Exartze, the Woven Stone"
+        }
       ]
     },
     "Cremated Archives": {
       "bosses": [
-        [
-          "Exartze, the Woven Stone"
-        ]
+        {
+          "name": "Exartze, the Woven Stone"
+        }
       ]
     },
     "Twisted Inquisitorium": {
       "bosses": [
-        [
-          "Anacuacotli, Death's Worship"
-        ]
+        {
+          "name": "Anacuacotli, Death's Worship"
+        }
       ]
     },
     "Deathly Chambers": {
       "bosses": [
-        [
-          "Harbinger of Disorder"
-        ]
+        {
+          "name": "Harbinger of Disorder"
+        }
       ]
     },
     "Restricted Collection": {
       "bosses": [
-        [
-          "Iorphia, Dream Eater"
-        ]
+        {
+          "name": "Iorphia, Dream Eater"
+        }
       ]
     },
     "Side Chapel": {
       "bosses": [
-        [
-          "Daluatti, Stoneraiser"
-        ]
+        {
+          "name": "Daluatti, Stoneraiser"
+        }
       ]
     },
     "Radiant Pools": {
       "bosses": [
-        [
-          "Perquil the Lucky"
-        ]
+        {
+          "name": "Perquil the Lucky"
+        }
       ]
     },
     "Clouded Ledge": {
       "bosses": [
-        [
-          "Simi, the Nature Touched"
-        ]
+        {
+          "name": "Simi, the Nature Touched"
+        }
       ]
     },
     "Sealed Repository": {
       "bosses": [
-        [
-          "Inti of the Blood Moon"
-        ]
+        {
+          "name": "Inti of the Blood Moon"
+        }
       ]
     },
     "Flooded Complex": {
       "bosses": [
-        [
-          "M'gaska, the Living Pyre"
-        ]
+        {
+          "name": "M'gaska, the Living Pyre"
+        }
       ]
     },
     "Forbidden Shrine": {
       "bosses": [
-        [
-          "Shrapnelbearer"
-        ]
+        {
+          "name": "Shrapnelbearer"
+        }
       ]
     },
     "Evacuated Quarter": {
       "bosses": [
-        [
-          "Curator Miem"
-        ]
+        {
+          "name": "Curator Miem"
+        }
       ]
     },
     "Concealed Caldarium": {
       "bosses": [
-        [
-          "Cava, Artist of Pain"
-        ]
+        {
+          "name": "Cava, Artist of Pain"
+        }
       ]
     },
     "Moonlit Chambers": {
       "bosses": [
-        [
-          "Beheader Ataguchu"
-        ]
+        {
+          "name": "Beheader Ataguchu"
+        }
       ]
     },
     "Shifting Sands": {
       "bosses": [
-        [
-          "Wiraq, the Impaler"
-        ]
+        {
+          "name": "Wiraq, the Impaler"
+        }
       ]
     },
     "Forgotten Gulch": {
       "bosses": [
-        [
-          "Curator Miem"
-        ]
+        {
+          "name": "Curator Miem"
+        }
       ]
     },
     "Desolate Isle": {
       "bosses": [
-        [
-          "Wiraqucha, Ancient Guardian"
-        ]
+        {
+          "name": "Wiraqucha, Ancient Guardian"
+        }
       ]
     },
     "Dusty Bluff": {
       "bosses": [
-        [
-          "Quetzerxi"
-        ]
+        {
+          "name": "Quetzerxi"
+        }
       ]
     }
   },
   "labyrinth": {
-    "Aspirants' Plaza": {
-      "trial": false
-    },
-    "Trial of Piercing Truth": {
-      "trial": true
-    },
-    "Trial of Swirling Fear": {
-      "trial": true
-    },
-    "Trial of Crippling Grief": {
-      "trial": true
-    },
-    "Trial of Burning Rage": {
-      "trial": true
-    },
-    "Trial of Lingering Pain": {
-      "trial": true
-    },
-    "Trial of Stinging Doubt": {
-      "trial": true
-    }
+    "Aspirants' Plaza": [
+      {
+        "trial": false
+      }
+    ],
+    "Trial of Piercing Truth": [
+      {
+        "trial": true
+      }
+    ],
+    "Trial of Swirling Fear": [
+      {
+        "trial": true
+      }
+    ],
+    "Trial of Crippling Grief": [
+      {
+        "trial": true
+      }
+    ],
+    "Trial of Burning Rage": [
+      {
+        "trial": true
+      }
+    ],
+    "Trial of Lingering Pain": [
+      {
+        "trial": true
+      }
+    ],
+    "Trial of Stinging Doubt": [
+      {
+        "trial": true
+      }
+    ]
   },
   "map": {
     "Beach Map": [
@@ -2393,7 +2407,9 @@
         "level": 68,
         "tier": 1,
         "bosses": [
-          "Glace"
+          {
+            "name": "Glace"
+          }
         ]
       }
     ],
@@ -2402,7 +2418,9 @@
         "level": 68,
         "tier": 1,
         "bosses": [
-          "Penitentiary Incarcerator"
+          {
+            "name": "Penitentiary Incarcerator"
+          }
         ]
       }
     ],
@@ -2411,9 +2429,15 @@
         "level": 68,
         "tier": 1,
         "bosses": [
-          "Steelpoint the Avenger",
-          "Champion of Frost",
-          "Thunderskull"
+          {
+            "name": "Steelpoint the Avenger"
+          },
+          {
+            "name": "Champion of Frost"
+          },
+          {
+            "name": "Thunderskull"
+          }
         ]
       }
     ],
@@ -2422,7 +2446,9 @@
         "level": 68,
         "tier": 1,
         "bosses": [
-          "The Grey Plague"
+          {
+            "name": "The Grey Plague"
+          }
         ]
       }
     ],
@@ -2431,7 +2457,9 @@
         "level": 69,
         "tier": 2,
         "bosses": [
-          "Calderus"
+          {
+            "name": "Calderus"
+          }
         ]
       }
     ],
@@ -2440,7 +2468,9 @@
         "level": 69,
         "tier": 2,
         "bosses": [
-          "Drought-Maddened Rhoa"
+          {
+            "name": "Drought-Maddened Rhoa"
+          }
         ]
       }
     ],
@@ -2449,7 +2479,9 @@
         "level": 69,
         "tier": 2,
         "bosses": [
-          "Preethi, Eye-Pecker"
+          {
+            "name": "Preethi, Eye-Pecker"
+          }
         ]
       }
     ],
@@ -2458,7 +2490,9 @@
         "level": 69,
         "tier": 2,
         "bosses": [
-          "The Eroding One"
+          {
+            "name": "The Eroding One"
+          }
         ]
       }
     ],
@@ -2467,7 +2501,9 @@
         "level": 69,
         "tier": 2,
         "bosses": [
-          "Tore, Towering Ancient"
+          {
+            "name": "Tore, Towering Ancient"
+          }
         ]
       }
     ],
@@ -2476,7 +2512,9 @@
         "level": 69,
         "tier": 2,
         "bosses": [
-          "Arwyn, the Houndmaster"
+          {
+            "name": "Arwyn, the Houndmaster"
+          }
         ]
       }
     ],
@@ -2485,8 +2523,12 @@
         "level": 70,
         "tier": 3,
         "bosses": [
-          "Herald of Ashes",
-          "Herald of Thunder"
+          {
+            "name": "Herald of Ashes"
+          },
+          {
+            "name": "Herald of Thunder"
+          }
         ]
       }
     ],
@@ -2495,7 +2537,9 @@
         "level": 70,
         "tier": 3,
         "bosses": [
-          "Witch of the Cauldron"
+          {
+            "name": "Witch of the Cauldron"
+          }
         ]
       }
     ],
@@ -2504,7 +2548,9 @@
         "level": 70,
         "tier": 3,
         "bosses": [
-          "Executioner Bloodwing"
+          {
+            "name": "Executioner Bloodwing"
+          }
         ]
       }
     ],
@@ -2513,7 +2559,9 @@
         "level": 70,
         "tier": 3,
         "bosses": [
-          "Megaera"
+          {
+            "name": "Megaera"
+          }
         ]
       }
     ],
@@ -2522,8 +2570,12 @@
         "level": 70,
         "tier": 3,
         "bosses": [
-          "Shrieker Eihal",
-          "Breaker Toruul"
+          {
+            "name": "Shrieker Eihal"
+          },
+          {
+            "name": "Breaker Toruul"
+          }
         ]
       }
     ],
@@ -2532,7 +2584,9 @@
         "level": 70,
         "tier": 3,
         "bosses": [
-          "One random Mutewind Warband boss with a supporting Warband"
+          {
+            "name": "One random Mutewind Warband boss with a supporting Warband"
+          }
         ]
       }
     ],
@@ -2541,7 +2595,9 @@
         "level": 70,
         "tier": 3,
         "bosses": [
-          "Mirage of Bones"
+          {
+            "name": "Mirage of Bones"
+          }
         ]
       }
     ],
@@ -2550,7 +2606,9 @@
         "level": 70,
         "tier": 3,
         "bosses": [
-          "Titan of the Grove"
+          {
+            "name": "Titan of the Grove"
+          }
         ]
       }
     ],
@@ -2559,7 +2617,9 @@
         "level": 70,
         "tier": 3,
         "bosses": [
-          "Unravelling Horror"
+          {
+            "name": "Unravelling Horror"
+          }
         ]
       }
     ],
@@ -2568,7 +2628,9 @@
         "level": 70,
         "tier": 3,
         "bosses": [
-          "Aulen Greychain"
+          {
+            "name": "Aulen Greychain"
+          }
         ]
       }
     ],
@@ -2577,7 +2639,9 @@
         "level": 70,
         "tier": null,
         "bosses": [
-          "Esh, Forked Thought"
+          {
+            "name": "Esh, Forked Thought"
+          }
         ]
       }
     ],
@@ -2586,7 +2650,9 @@
         "level": 70,
         "tier": null,
         "bosses": [
-          "Tul, Creeping Avalanche"
+          {
+            "name": "Tul, Creeping Avalanche"
+          }
         ]
       }
     ],
@@ -2595,7 +2661,9 @@
         "level": 70,
         "tier": null,
         "bosses": [
-          "Xoph, Dark Embers"
+          {
+            "name": "Xoph, Dark Embers"
+          }
         ]
       }
     ],
@@ -2604,9 +2672,15 @@
         "level": 70,
         "tier": null,
         "bosses": [
-          "Atziri, Queen of the Vaal",
-          "Q'ura",
-          "Y'ara'az",
+          {
+            "name": "Atziri, Queen of the Vaal"
+          },
+          {
+            "name": "Q'ura"
+          },
+          {
+            "name": "Y'ara'az"
+          },
           "A'alai",
           "Vessel of the Vaal",
           "Vessel of the Vaal"
@@ -2618,8 +2692,12 @@
         "level": 71,
         "tier": 4,
         "bosses": [
-          "Gnar, Eater of Carrion",
-          "Stonebeak, Battle Fowl"
+          {
+            "name": "Gnar, Eater of Carrion"
+          },
+          {
+            "name": "Stonebeak, Battle Fowl"
+          }
         ]
       }
     ],
@@ -2628,7 +2706,9 @@
         "level": 71,
         "tier": 4,
         "bosses": [
-          "The Reaver"
+          {
+            "name": "The Reaver"
+          }
         ]
       }
     ],
@@ -2637,9 +2717,15 @@
         "level": 71,
         "tier": 4,
         "bosses": [
-          "Carius, the Unnatural",
-          "Pileah, Corpse Burner",
-          "Pileah, Burning Corpse"
+          {
+            "name": "Carius, the Unnatural"
+          },
+          {
+            "name": "Pileah, Corpse Burner"
+          },
+          {
+            "name": "Pileah, Burning Corpse"
+          }
         ]
       }
     ],
@@ -2648,9 +2734,15 @@
         "level": 71,
         "tier": 4,
         "bosses": [
-          "Thena Moga, The Crimson Storm",
-          "Ion Darkshroud, The Hungering Blade",
-          "Bolt Brownfur, Earth Churner"
+          {
+            "name": "Thena Moga, The Crimson Storm"
+          },
+          {
+            "name": "Ion Darkshroud, The Hungering Blade"
+          },
+          {
+            "name": "Bolt Brownfur, Earth Churner"
+          }
         ]
       }
     ],
@@ -2659,7 +2751,9 @@
         "level": 71,
         "tier": 4,
         "bosses": [
-          "Rek'tar, the Breaker"
+          {
+            "name": "Rek'tar, the Breaker"
+          }
         ]
       }
     ],
@@ -2668,7 +2762,9 @@
         "level": 71,
         "tier": 4,
         "bosses": [
-          "Void Anomaly"
+          {
+            "name": "Void Anomaly"
+          }
         ]
       }
     ],
@@ -2677,7 +2773,9 @@
         "level": 71,
         "tier": 4,
         "bosses": [
-          "One random Redblade Warband boss with a supporting Warband"
+          {
+            "name": "One random Redblade Warband boss with a supporting Warband"
+          }
         ]
       }
     ],
@@ -2686,7 +2784,9 @@
         "level": 71,
         "tier": 4,
         "bosses": [
-          "Litanius, the Black Prayer"
+          {
+            "name": "Litanius, the Black Prayer"
+          }
         ]
       }
     ],
@@ -2695,7 +2795,9 @@
         "level": 71,
         "tier": 4,
         "bosses": [
-          "Master of the Blade Massier"
+          {
+            "name": "Master of the Blade Massier"
+          }
         ]
       }
     ],
@@ -2704,7 +2806,9 @@
         "level": 71,
         "tier": 4,
         "bosses": [
-          "Tormented Temptress"
+          {
+            "name": "Tormented Temptress"
+          }
         ]
       }
     ],
@@ -2713,7 +2817,9 @@
         "level": 71,
         "tier": 4,
         "bosses": [
-          "Forest of Flames"
+          {
+            "name": "Forest of Flames"
+          }
         ]
       }
     ],
@@ -2722,7 +2828,9 @@
         "level": 72,
         "tier": 5,
         "bosses": [
-          "Lady Stormflay"
+          {
+            "name": "Lady Stormflay"
+          }
         ]
       }
     ],
@@ -2731,7 +2839,9 @@
         "level": 72,
         "tier": 5,
         "bosses": [
-          "Beast of the Pits"
+          {
+            "name": "Beast of the Pits"
+          }
         ]
       }
     ],
@@ -2740,7 +2850,9 @@
         "level": 72,
         "tier": 5,
         "bosses": [
-          "The Winged Death"
+          {
+            "name": "The Winged Death"
+          }
         ]
       }
     ],
@@ -2749,7 +2861,9 @@
         "level": 72,
         "tier": 5,
         "bosses": [
-          "The Forgotten Soldier"
+          {
+            "name": "The Forgotten Soldier"
+          }
         ]
       }
     ],
@@ -2758,8 +2872,12 @@
         "level": 72,
         "tier": 5,
         "bosses": [
-          "Barthol, the Pure",
-          "Barthol, the Corrupter"
+          {
+            "name": "Barthol, the Pure"
+          },
+          {
+            "name": "Barthol, the Corrupter"
+          }
         ]
       }
     ],
@@ -2768,7 +2886,9 @@
         "level": 72,
         "tier": 5,
         "bosses": [
-          "One random Perandus Manor boss"
+          {
+            "name": "One random Perandus Manor boss"
+          }
         ]
       }
     ],
@@ -2777,7 +2897,9 @@
         "level": 72,
         "tier": 5,
         "bosses": [
-          "Shadow of the Vaal"
+          {
+            "name": "Shadow of the Vaal"
+          }
         ]
       }
     ],
@@ -2786,7 +2908,9 @@
         "level": 72,
         "tier": 5,
         "bosses": [
-          "Thraxia"
+          {
+            "name": "Thraxia"
+          }
         ]
       }
     ],
@@ -2795,7 +2919,9 @@
         "level": 72,
         "tier": 5,
         "bosses": [
-          "The Gorgon"
+          {
+            "name": "The Gorgon"
+          }
         ]
       }
     ],
@@ -2804,7 +2930,9 @@
         "level": 72,
         "tier": 5,
         "bosses": [
-          "Arachnoxia"
+          {
+            "name": "Arachnoxia"
+          }
         ]
       }
     ],
@@ -2820,7 +2948,9 @@
         "level": 73,
         "tier": 6,
         "bosses": [
-          "The Arbiter of Knowledge"
+          {
+            "name": "The Arbiter of Knowledge"
+          }
         ]
       }
     ],
@@ -2829,7 +2959,9 @@
         "level": 73,
         "tier": 6,
         "bosses": [
-          "Puruna, the Challenger"
+          {
+            "name": "Puruna, the Challenger"
+          }
         ]
       }
     ],
@@ -2838,8 +2970,12 @@
         "level": 73,
         "tier": 6,
         "bosses": [
-          "Merveil, the Reflection",
-          "Merveil, the Returned"
+          {
+            "name": "Merveil, the Reflection"
+          },
+          {
+            "name": "Merveil, the Returned"
+          }
         ]
       }
     ],
@@ -2848,7 +2984,9 @@
         "level": 73,
         "tier": 6,
         "bosses": [
-          "Lord of the Ashen Arrow"
+          {
+            "name": "Lord of the Ashen Arrow"
+          }
         ]
       }
     ],
@@ -2857,7 +2995,9 @@
         "level": 73,
         "tier": 6,
         "bosses": [
-          "Erebix, Light's Bane"
+          {
+            "name": "Erebix, Light's Bane"
+          }
         ]
       }
     ],
@@ -2866,7 +3006,9 @@
         "level": 73,
         "tier": 6,
         "bosses": [
-          "Maker of Mires"
+          {
+            "name": "Maker of Mires"
+          }
         ]
       }
     ],
@@ -2875,7 +3017,9 @@
         "level": 73,
         "tier": 6,
         "bosses": [
-          "Drek, Apex Hunter"
+          {
+            "name": "Drek, Apex Hunter"
+          }
         ]
       }
     ],
@@ -2884,7 +3028,9 @@
         "level": 73,
         "tier": 6,
         "bosses": [
-          "Queen of the Great Tangle"
+          {
+            "name": "Queen of the Great Tangle"
+          }
         ]
       }
     ],
@@ -2893,7 +3039,9 @@
         "level": 73,
         "tier": 6,
         "bosses": [
-          "Tolman, the Exhumer"
+          {
+            "name": "Tolman, the Exhumer"
+          }
         ]
       }
     ],
@@ -2902,7 +3050,9 @@
         "level": 73,
         "tier": 6,
         "bosses": [
-          "Erythrophagia"
+          {
+            "name": "Erythrophagia"
+          }
         ]
       }
     ],
@@ -2911,7 +3061,9 @@
         "level": 73,
         "tier": 6,
         "bosses": [
-          "The Primal One"
+          {
+            "name": "The Primal One"
+          }
         ]
       }
     ],
@@ -2920,7 +3072,9 @@
         "level": 73,
         "tier": 6,
         "bosses": [
-          "Merveil, the Reflection"
+          {
+            "name": "Merveil, the Reflection"
+          }
         ]
       }
     ],
@@ -2929,7 +3083,9 @@
         "level": 73,
         "tier": 6,
         "bosses": [
-          "Stone of the Currents"
+          {
+            "name": "Stone of the Currents"
+          }
         ]
       }
     ],
@@ -2938,7 +3094,9 @@
         "level": 74,
         "tier": 7,
         "bosses": [
-          "Spinner of False Hope"
+          {
+            "name": "Spinner of False Hope"
+          }
         ]
       }
     ],
@@ -2947,7 +3105,9 @@
         "level": 74,
         "tier": 7,
         "bosses": [
-          "Ancient Sculptor"
+          {
+            "name": "Ancient Sculptor"
+          }
         ]
       }
     ],
@@ -2956,7 +3116,9 @@
         "level": 74,
         "tier": 7,
         "bosses": [
-          "Xixic, High Necromancer"
+          {
+            "name": "Xixic, High Necromancer"
+          }
         ]
       }
     ],
@@ -2965,7 +3127,9 @@
         "level": 74,
         "tier": 7,
         "bosses": [
-          "Olmec, the All Stone"
+          {
+            "name": "Olmec, the All Stone"
+          }
         ]
       }
     ],
@@ -2974,7 +3138,9 @@
         "level": 74,
         "tier": 7,
         "bosses": [
-          "Captain Tanner Lightfoot"
+          {
+            "name": "Captain Tanner Lightfoot"
+          }
         ]
       }
     ],
@@ -2983,7 +3149,9 @@
         "level": 74,
         "tier": 7,
         "bosses": [
-          "The Blacksmith"
+          {
+            "name": "The Blacksmith"
+          }
         ]
       }
     ],
@@ -2992,7 +3160,9 @@
         "level": 74,
         "tier": 7,
         "bosses": [
-          "Talin, Faithbreaker"
+          {
+            "name": "Talin, Faithbreaker"
+          }
         ]
       }
     ],
@@ -3001,7 +3171,9 @@
         "level": 74,
         "tier": 7,
         "bosses": [
-          "Sallazzang"
+          {
+            "name": "Sallazzang"
+          }
         ]
       }
     ],
@@ -3010,7 +3182,9 @@
         "level": 74,
         "tier": 7,
         "bosses": [
-          "Fire and Fury"
+          {
+            "name": "Fire and Fury"
+          }
         ]
       }
     ],
@@ -3019,7 +3193,9 @@
         "level": 74,
         "tier": 7,
         "bosses": [
-          "Legius Garhall"
+          {
+            "name": "Legius Garhall"
+          }
         ]
       }
     ],
@@ -3028,7 +3204,9 @@
         "level": 74,
         "tier": 7,
         "bosses": [
-          "Excellis Aurafix"
+          {
+            "name": "Excellis Aurafix"
+          }
         ]
       }
     ],
@@ -3037,7 +3215,9 @@
         "level": 74,
         "tier": 7,
         "bosses": [
-          "Shavronne the Sickening"
+          {
+            "name": "Shavronne the Sickening"
+          }
         ]
       }
     ],
@@ -3046,7 +3226,9 @@
         "level": 74,
         "tier": 7,
         "bosses": [
-          "It That Fell"
+          {
+            "name": "It That Fell"
+          }
         ]
       }
     ],
@@ -3055,9 +3237,15 @@
         "level": 74,
         "tier": 7,
         "bosses": [
-          "Solus, Pack Alpha",
-          "Storm Eye",
-          "Winterfang"
+          {
+            "name": "Solus, Pack Alpha"
+          },
+          {
+            "name": "Storm Eye"
+          },
+          {
+            "name": "Winterfang"
+          }
         ]
       }
     ],
@@ -3066,7 +3254,9 @@
         "level": 75,
         "tier": 8,
         "bosses": [
-          "Warmonger"
+          {
+            "name": "Warmonger"
+          }
         ]
       }
     ],
@@ -3075,9 +3265,15 @@
         "level": 75,
         "tier": 8,
         "bosses": [
-          "Oriath's Vengeance",
-          "Oriath's Vigil",
-          "Oriath's Virtue"
+          {
+            "name": "Oriath's Vengeance"
+          },
+          {
+            "name": "Oriath's Vigil"
+          },
+          {
+            "name": "Oriath's Virtue"
+          }
         ]
       }
     ],
@@ -3086,7 +3282,9 @@
         "level": 75,
         "tier": 8,
         "bosses": [
-          "Avatar of Thunder"
+          {
+            "name": "Avatar of Thunder"
+          }
         ]
       }
     ],
@@ -3095,7 +3293,9 @@
         "level": 75,
         "tier": 8,
         "bosses": [
-          "Avatar of Undoing"
+          {
+            "name": "Avatar of Undoing"
+          }
         ]
       }
     ],
@@ -3104,7 +3304,9 @@
         "level": 75,
         "tier": 8,
         "bosses": [
-          "Gorulis, Will-Thief"
+          {
+            "name": "Gorulis, Will-Thief"
+          }
         ]
       }
     ],
@@ -3113,7 +3315,9 @@
         "level": 75,
         "tier": 8,
         "bosses": [
-          "Riftwalker"
+          {
+            "name": "Riftwalker"
+          }
         ]
       }
     ],
@@ -3122,8 +3326,12 @@
         "level": 75,
         "tier": 8,
         "bosses": [
-          "Merveil, the Reflection",
-          "Merveil, the Returned"
+          {
+            "name": "Merveil, the Reflection"
+          },
+          {
+            "name": "Merveil, the Returned"
+          }
         ]
       }
     ],
@@ -3132,7 +3340,9 @@
         "level": 75,
         "tier": 8,
         "bosses": [
-          "Tunneltrap"
+          {
+            "name": "Tunneltrap"
+          }
         ]
       }
     ],
@@ -3141,7 +3351,9 @@
         "level": 75,
         "tier": 8,
         "bosses": [
-          "Visceris"
+          {
+            "name": "Visceris"
+          }
         ]
       }
     ],
@@ -3150,7 +3362,9 @@
         "level": 75,
         "tier": 8,
         "bosses": [
-          "Belcer, the Pirate Lord"
+          {
+            "name": "Belcer, the Pirate Lord"
+          }
         ]
       }
     ],
@@ -3159,7 +3373,9 @@
         "level": 75,
         "tier": 8,
         "bosses": [
-          "Fairgraves, Never Dying"
+          {
+            "name": "Fairgraves, Never Dying"
+          }
         ]
       }
     ],
@@ -3168,9 +3384,15 @@
         "level": 75,
         "tier": null,
         "bosses": [
-          "Eber, the Plaguemaw",
-          "Inya, the Unbearable Whispers",
-          "Volkuur, the Unbreathing Queen",
+          {
+            "name": "Eber, the Plaguemaw"
+          },
+          {
+            "name": "Inya, the Unbearable Whispers"
+          },
+          {
+            "name": "Volkuur, the Unbreathing Queen"
+          },
           "Yriel, the Feral Lord"
         ]
       }
@@ -3180,7 +3402,9 @@
         "level": 75,
         "tier": 8,
         "bosses": [
-          "Blood Progenitor"
+          {
+            "name": "Blood Progenitor"
+          }
         ]
       }
     ],
@@ -3189,7 +3413,9 @@
         "level": 75,
         "tier": null,
         "bosses": [
-          "Uul-Netol, Unburdened Flesh"
+          {
+            "name": "Uul-Netol, Unburdened Flesh"
+          }
         ]
       }
     ],
@@ -3198,9 +3424,15 @@
         "level": 75,
         "tier": 8,
         "bosses": [
-          "Clutch Queen",
-          "Colossal Spitter",
-          "Elder Devourer",
+          {
+            "name": "Clutch Queen"
+          },
+          {
+            "name": "Colossal Spitter"
+          },
+          {
+            "name": "Elder Devourer"
+          },
           "Great Maw",
           "Prime Ape",
           "The First Rhoa"
@@ -3212,9 +3444,15 @@
         "level": 75,
         "tier": 8,
         "bosses": [
-          "The Fallen Queen",
-          "The Hollow Lady",
-          "The Broken Prince"
+          {
+            "name": "The Fallen Queen"
+          },
+          {
+            "name": "The Hollow Lady"
+          },
+          {
+            "name": "The Broken Prince"
+          }
         ]
       }
     ],
@@ -3223,7 +3461,9 @@
         "level": 75,
         "tier": 8,
         "bosses": [
-          "(none)"
+          {
+            "name": "(none)"
+          }
         ]
       }
     ],
@@ -3232,9 +3472,15 @@
         "level": 76,
         "tier": 9,
         "bosses": [
-          "Avatar of the Forge",
-          "Avatar of the Huntress",
-          "Avatar of the Skies"
+          {
+            "name": "Avatar of the Forge"
+          },
+          {
+            "name": "Avatar of the Huntress"
+          },
+          {
+            "name": "Avatar of the Skies"
+          }
         ]
       }
     ],
@@ -3243,7 +3489,9 @@
         "level": 76,
         "tier": 9,
         "bosses": [
-          "Sumter the Twisted"
+          {
+            "name": "Sumter the Twisted"
+          }
         ]
       }
     ],
@@ -3252,7 +3500,9 @@
         "level": 76,
         "tier": 9,
         "bosses": [
-          "Sebbert, Crescent's Point"
+          {
+            "name": "Sebbert, Crescent's Point"
+          }
         ]
       }
     ],
@@ -3261,8 +3511,12 @@
         "level": 76,
         "tier": 9,
         "bosses": [
-          "Helial, the Day Unending",
-          "Selenia, the Endless Night"
+          {
+            "name": "Helial, the Day Unending"
+          },
+          {
+            "name": "Selenia, the Endless Night"
+          }
         ]
       }
     ],
@@ -3271,7 +3525,9 @@
         "level": 76,
         "tier": 9,
         "bosses": [
-          "He of Many Pieces"
+          {
+            "name": "He of Many Pieces"
+          }
         ]
       }
     ],
@@ -3280,7 +3536,9 @@
         "level": 76,
         "tier": 9,
         "bosses": [
-          "Headmistress Braeta"
+          {
+            "name": "Headmistress Braeta"
+          }
         ]
       }
     ],
@@ -3289,8 +3547,12 @@
         "level": 76,
         "tier": 9,
         "bosses": [
-          "Puruna, the Challenger",
-          "Poporo, the Highest Spire"
+          {
+            "name": "Puruna, the Challenger"
+          },
+          {
+            "name": "Poporo, the Highest Spire"
+          }
         ]
       }
     ],
@@ -3299,7 +3561,9 @@
         "level": 76,
         "tier": 9,
         "bosses": [
-          "Gisale, Thought Thief"
+          {
+            "name": "Gisale, Thought Thief"
+          }
         ]
       }
     ],
@@ -3308,7 +3572,9 @@
         "level": 76,
         "tier": 9,
         "bosses": [
-          "Doedre the Defiler"
+          {
+            "name": "Doedre the Defiler"
+          }
         ]
       }
     ],
@@ -3317,7 +3583,9 @@
         "level": 76,
         "tier": 9,
         "bosses": [
-          "Jorus, Sky's Edge"
+          {
+            "name": "Jorus, Sky's Edge"
+          }
         ]
       }
     ],
@@ -3326,7 +3594,9 @@
         "level": 76,
         "tier": 9,
         "bosses": [
-          "Mistress Hyseria"
+          {
+            "name": "Mistress Hyseria"
+          }
         ]
       }
     ],
@@ -3335,7 +3605,9 @@
         "level": 76,
         "tier": 9,
         "bosses": [
-          "Liantra Bazur"
+          {
+            "name": "Liantra Bazur"
+          }
         ]
       }
     ],
@@ -3344,7 +3616,9 @@
         "level": 76,
         "tier": 9,
         "bosses": [
-          "Guardian of the Vault"
+          {
+            "name": "Guardian of the Vault"
+          }
         ]
       }
     ],
@@ -3353,7 +3627,9 @@
         "level": 76,
         "tier": 9,
         "bosses": [
-          "Portentia, the Foul"
+          {
+            "name": "Portentia, the Foul"
+          }
         ]
       }
     ],
@@ -3362,7 +3638,9 @@
         "level": 77,
         "tier": 10,
         "bosses": [
-          "Hybrid Widow"
+          {
+            "name": "Hybrid Widow"
+          }
         ]
       }
     ],
@@ -3371,7 +3649,9 @@
         "level": 77,
         "tier": 10,
         "bosses": [
-          "Lord of the Grey"
+          {
+            "name": "Lord of the Grey"
+          }
         ]
       }
     ],
@@ -3380,7 +3660,9 @@
         "level": 77,
         "tier": 10,
         "bosses": [
-          "Skullbeak"
+          {
+            "name": "Skullbeak"
+          }
         ]
       }
     ],
@@ -3389,7 +3671,9 @@
         "level": 77,
         "tier": 10,
         "bosses": [
-          "Pagan Bishop of Agony"
+          {
+            "name": "Pagan Bishop of Agony"
+          }
         ]
       }
     ],
@@ -3398,7 +3682,9 @@
         "level": 77,
         "tier": 10,
         "bosses": [
-          "Infector of Dreams"
+          {
+            "name": "Infector of Dreams"
+          }
         ]
       }
     ],
@@ -3407,7 +3693,9 @@
         "level": 77,
         "tier": 10,
         "bosses": [
-          "Vision of Justice"
+          {
+            "name": "Vision of Justice"
+          }
         ]
       }
     ],
@@ -3416,7 +3704,9 @@
         "level": 77,
         "tier": 10,
         "bosses": [
-          "Ancient Architect"
+          {
+            "name": "Ancient Architect"
+          }
         ]
       }
     ],
@@ -3425,7 +3715,9 @@
         "level": 77,
         "tier": 10,
         "bosses": [
-          "Three random Rogue Exiles"
+          {
+            "name": "Three random Rogue Exiles"
+          }
         ]
       }
     ],
@@ -3434,7 +3726,9 @@
         "level": 77,
         "tier": 10,
         "bosses": [
-          "One random Brinerot Warband boss with a supporting Warband"
+          {
+            "name": "One random Brinerot Warband boss with a supporting Warband"
+          }
         ]
       }
     ],
@@ -3443,7 +3737,9 @@
         "level": 77,
         "tier": 10,
         "bosses": [
-          "Tahsin, Warmaker"
+          {
+            "name": "Tahsin, Warmaker"
+          }
         ]
       }
     ],
@@ -3452,7 +3748,9 @@
         "level": 77,
         "tier": 10,
         "bosses": [
-          ""
+          {
+            "name": ""
+          }
         ]
       }
     ],
@@ -3461,7 +3759,9 @@
         "level": 77,
         "tier": 10,
         "bosses": [
-          "The Brittle Emperor"
+          {
+            "name": "The Brittle Emperor"
+          }
         ]
       }
     ],
@@ -3470,7 +3770,9 @@
         "level": 78,
         "tier": 11,
         "bosses": [
-          "Tyrant"
+          {
+            "name": "Tyrant"
+          }
         ]
       }
     ],
@@ -3479,7 +3781,9 @@
         "level": 78,
         "tier": 11,
         "bosses": [
-          "Telvar, the Inebriated Pirate Treasure"
+          {
+            "name": "Telvar, the Inebriated Pirate Treasure"
+          }
         ]
       }
     ],
@@ -3488,7 +3792,9 @@
         "level": 78,
         "tier": 11,
         "bosses": [
-          "Pesquin, the Mad Baron"
+          {
+            "name": "Pesquin, the Mad Baron"
+          }
         ]
       }
     ],
@@ -3497,7 +3803,9 @@
         "level": 78,
         "tier": 11,
         "bosses": [
-          "Oak the Mighty"
+          {
+            "name": "Oak the Mighty"
+          }
         ]
       }
     ],
@@ -3506,7 +3814,9 @@
         "level": 78,
         "tier": 11,
         "bosses": [
-          "Lycius, Midnight's Howl"
+          {
+            "name": "Lycius, Midnight's Howl"
+          }
         ]
       }
     ],
@@ -3515,7 +3825,9 @@
         "level": 78,
         "tier": 11,
         "bosses": [
-          "Olof, Son of the Headsman"
+          {
+            "name": "Olof, Son of the Headsman"
+          }
         ]
       }
     ],
@@ -3524,7 +3836,9 @@
         "level": 78,
         "tier": 11,
         "bosses": [
-          "Nightmare's Omen"
+          {
+            "name": "Nightmare's Omen"
+          }
         ]
       }
     ],
@@ -3533,7 +3847,9 @@
         "level": 78,
         "tier": 11,
         "bosses": [
-          "Blackguard Avenger Blackguard Tempest"
+          {
+            "name": "Blackguard Avenger Blackguard Tempest"
+          }
         ]
       }
     ],
@@ -3542,7 +3858,9 @@
         "level": 78,
         "tier": 11,
         "bosses": [
-          "(none)*"
+          {
+            "name": "(none)*"
+          }
         ]
       }
     ],
@@ -3551,7 +3869,9 @@
         "level": 78,
         "tier": 11,
         "bosses": [
-          "Enticer of Rot"
+          {
+            "name": "Enticer of Rot"
+          }
         ]
       }
     ],
@@ -3560,7 +3880,9 @@
         "level": 78,
         "tier": 11,
         "bosses": [
-          "Fragment of Winter"
+          {
+            "name": "Fragment of Winter"
+          }
         ]
       }
     ],
@@ -3569,7 +3891,9 @@
         "level": 79,
         "tier": 12,
         "bosses": [
-          "Leif, the Swift-Handed"
+          {
+            "name": "Leif, the Swift-Handed"
+          }
         ]
       }
     ],
@@ -3578,7 +3902,9 @@
         "level": 79,
         "tier": 12,
         "bosses": [
-          "Champion of the Hollows Lord of the Hollows Messenger of the Hollows"
+          {
+            "name": "Champion of the Hollows Lord of the Hollows Messenger of the Hollows"
+          }
         ]
       }
     ],
@@ -3587,7 +3913,9 @@
         "level": 79,
         "tier": 12,
         "bosses": [
-          "Woad, Mockery of Man"
+          {
+            "name": "Woad, Mockery of Man"
+          }
         ]
       }
     ],
@@ -3596,7 +3924,9 @@
         "level": 79,
         "tier": 12,
         "bosses": [
-          "Burtok, Conjuror of Bones"
+          {
+            "name": "Burtok, Conjuror of Bones"
+          }
         ]
       }
     ],
@@ -3605,7 +3935,9 @@
         "level": 79,
         "tier": 12,
         "bosses": [
-          "Avatar of Apocalypse"
+          {
+            "name": "Avatar of Apocalypse"
+          }
         ]
       }
     ],
@@ -3614,7 +3946,9 @@
         "level": 79,
         "tier": 12,
         "bosses": [
-          "Maligaro the Mutilator"
+          {
+            "name": "Maligaro the Mutilator"
+          }
         ]
       }
     ],
@@ -3623,7 +3957,9 @@
         "level": 79,
         "tier": 12,
         "bosses": [
-          "Rose Thorn"
+          {
+            "name": "Rose Thorn"
+          }
         ]
       }
     ],
@@ -3632,7 +3968,9 @@
         "level": 79,
         "tier": 12,
         "bosses": [
-          "Shredder of Gladiators Crusher of Gladiators Bringer of Blood"
+          {
+            "name": "Shredder of Gladiators Crusher of Gladiators Bringer of Blood"
+          }
         ]
       }
     ],
@@ -3641,7 +3979,9 @@
         "level": 79,
         "tier": 12,
         "bosses": [
-          "Mephod, the Earth Scorcher"
+          {
+            "name": "Mephod, the Earth Scorcher"
+          }
         ]
       }
     ],
@@ -3650,7 +3990,9 @@
         "level": 79,
         "tier": 12,
         "bosses": [
-          "Shock and Horror"
+          {
+            "name": "Shock and Horror"
+          }
         ]
       }
     ],
@@ -3666,7 +4008,9 @@
         "level": 79,
         "tier": 12,
         "bosses": [
-          "The High Templar"
+          {
+            "name": "The High Templar"
+          }
         ]
       }
     ],
@@ -3675,7 +4019,9 @@
         "level": 80,
         "tier": 13,
         "bosses": [
-          "The Steel Soul"
+          {
+            "name": "The Steel Soul"
+          }
         ]
       }
     ],
@@ -3684,7 +4030,9 @@
         "level": 80,
         "tier": 13,
         "bosses": [
-          "The Infernal King"
+          {
+            "name": "The Infernal King"
+          }
         ]
       }
     ],
@@ -3693,7 +4041,9 @@
         "level": 80,
         "tier": 13,
         "bosses": [
-          "Eater of Souls"
+          {
+            "name": "Eater of Souls"
+          }
         ]
       }
     ],
@@ -3702,7 +4052,9 @@
         "level": 80,
         "tier": null,
         "bosses": [
-          "Chayula, Who Dreamt"
+          {
+            "name": "Chayula, Who Dreamt"
+          }
         ]
       }
     ],
@@ -3711,7 +4063,9 @@
         "level": 80,
         "tier": 13,
         "bosses": [
-          "Terror of the Infinite Drifts"
+          {
+            "name": "Terror of the Infinite Drifts"
+          }
         ]
       }
     ],
@@ -3720,7 +4074,9 @@
         "level": 80,
         "tier": 13,
         "bosses": [
-          "Hephaeus, The Hammer"
+          {
+            "name": "Hephaeus, The Hammer"
+          }
         ]
       }
     ],
@@ -3729,7 +4085,9 @@
         "level": 80,
         "tier": 13,
         "bosses": [
-          "Nightmare Manifest"
+          {
+            "name": "Nightmare Manifest"
+          }
         ]
       }
     ],
@@ -3738,7 +4096,9 @@
         "level": 80,
         "tier": 13,
         "bosses": [
-          "Suncaller Asha"
+          {
+            "name": "Suncaller Asha"
+          }
         ]
       }
     ],
@@ -3747,7 +4107,9 @@
         "level": 80,
         "tier": 13,
         "bosses": [
-          "Piety the Empyrean"
+          {
+            "name": "Piety the Empyrean"
+          }
         ]
       }
     ],
@@ -3756,7 +4118,9 @@
         "level": 80,
         "tier": 13,
         "bosses": [
-          "Varhesh, Shimmering Aberration"
+          {
+            "name": "Varhesh, Shimmering Aberration"
+          }
         ]
       }
     ],
@@ -3765,9 +4129,15 @@
         "level": 80,
         "tier": null,
         "bosses": [
-          "Atziri, Queen of the Vaal",
-          "Q'ura",
-          "Y'ara'az",
+          {
+            "name": "Atziri, Queen of the Vaal"
+          },
+          {
+            "name": "Q'ura"
+          },
+          {
+            "name": "Y'ara'az"
+          },
           "A'alai",
           "Vessel of the Vaal",
           "Vessel of the Vaal"
@@ -3779,7 +4149,9 @@
         "level": 81,
         "tier": 14,
         "bosses": [
-          "Two random Renegades Warband bosses with a supporting Warband"
+          {
+            "name": "Two random Renegades Warband bosses with a supporting Warband"
+          }
         ]
       }
     ],
@@ -3788,7 +4160,9 @@
         "level": 81,
         "tier": 14,
         "bosses": [
-          "Ambrius, Legion Slayer"
+          {
+            "name": "Ambrius, Legion Slayer"
+          }
         ]
       }
     ],
@@ -3797,7 +4171,9 @@
         "level": 81,
         "tier": 14,
         "bosses": [
-          "The Sanguine Siren"
+          {
+            "name": "The Sanguine Siren"
+          }
         ]
       }
     ],
@@ -3806,7 +4182,9 @@
         "level": 81,
         "tier": 14,
         "bosses": [
-          "The Cursed King"
+          {
+            "name": "The Cursed King"
+          }
         ]
       }
     ],
@@ -3815,7 +4193,9 @@
         "level": 81,
         "tier": 14,
         "bosses": [
-          "Stalker of the Endless Dunes"
+          {
+            "name": "Stalker of the Endless Dunes"
+          }
         ]
       }
     ],
@@ -3824,7 +4204,9 @@
         "level": 81,
         "tier": 14,
         "bosses": [
-          "God's Chosen The Hallowed Husk"
+          {
+            "name": "God's Chosen The Hallowed Husk"
+          }
         ]
       }
     ],
@@ -3833,7 +4215,9 @@
         "level": 81,
         "tier": 14,
         "bosses": [
-          "The Goddess"
+          {
+            "name": "The Goddess"
+          }
         ]
       }
     ],
@@ -3842,8 +4226,12 @@
         "level": 82,
         "tier": 15,
         "bosses": [
-          "Konley, the Unrepentant",
-          "The Cleansing Light"
+          {
+            "name": "Konley, the Unrepentant"
+          },
+          {
+            "name": "The Cleansing Light"
+          }
         ]
       }
     ],
@@ -3852,7 +4240,9 @@
         "level": 82,
         "tier": 15,
         "bosses": [
-          "Amalgam of Nightmares"
+          {
+            "name": "Amalgam of Nightmares"
+          }
         ]
       }
     ],
@@ -3861,7 +4251,9 @@
         "level": 82,
         "tier": 15,
         "bosses": [
-          "Kitava, the Insatiable"
+          {
+            "name": "Kitava, the Insatiable"
+          }
         ]
       }
     ],
@@ -3870,7 +4262,9 @@
         "level": 82,
         "tier": 15,
         "bosses": [
-          "Nassar, Lion of the Seas"
+          {
+            "name": "Nassar, Lion of the Seas"
+          }
         ]
       }
     ],
@@ -3879,7 +4273,9 @@
         "level": 82,
         "tier": 15,
         "bosses": [
-          "Armala, the Widow"
+          {
+            "name": "Armala, the Widow"
+          }
         ]
       }
     ],
@@ -3888,7 +4284,9 @@
         "level": 82,
         "tier": 15,
         "bosses": [
-          ""
+          {
+            "name": ""
+          }
         ]
       }
     ],
@@ -3897,7 +4295,9 @@
         "level": 83,
         "tier": 16,
         "bosses": [
-          "Guardian of the Phoenix"
+          {
+            "name": "Guardian of the Phoenix"
+          }
         ]
       }
     ],
@@ -3906,7 +4306,9 @@
         "level": 83,
         "tier": 16,
         "bosses": [
-          "Guardian of the Hydra"
+          {
+            "name": "Guardian of the Hydra"
+          }
         ]
       }
     ],
@@ -3915,7 +4317,9 @@
         "level": 83,
         "tier": 16,
         "bosses": [
-          "Guardian of the Minotaur"
+          {
+            "name": "Guardian of the Minotaur"
+          }
         ]
       }
     ],
@@ -3924,7 +4328,9 @@
         "level": 83,
         "tier": 16,
         "bosses": [
-          "Guardian of the Chimera"
+          {
+            "name": "Guardian of the Chimera"
+          }
         ]
       }
     ],
@@ -3933,9 +4339,15 @@
         "level": 83,
         "tier": 16,
         "bosses": [
-          "K'aj A'alai",
-          "K'aj Q'ura",
-          "K'aj Y'ara'az"
+          {
+            "name": "K'aj A'alai"
+          },
+          {
+            "name": "K'aj Q'ura"
+          },
+          {
+            "name": "K'aj Y'ara'az"
+          }
         ]
       }
     ],
@@ -3944,7 +4356,9 @@
         "level": 84,
         "tier": null,
         "bosses": [
-          "The Shaper"
+          {
+            "name": "The Shaper"
+          }
         ]
       }
     ]

--- a/resource/areas.json
+++ b/resource/areas.json
@@ -1,2492 +1,2067 @@
 {
-  "area":{
-    "Unearthed Hideout":[
-      {
-        "act":1,
-        "level":20,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
+	"area": {
+		"Unearthed Hideout": [{
+			"act": 1,
+			"level": 20,
+			"town": false,
+			"waypoint": true,
+			"bosses": [
 
-        ]
-      }
-    ],
-    "Enlightened Hideout":[
-      {
-        "act":1,
-        "level":20,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
+			]
+		}],
+		"Enlightened Hideout": [{
+			"act": 1,
+			"level": 20,
+			"town": false,
+			"waypoint": true,
+			"bosses": [
 
-        ]
-      }
-    ],
-    "Coastal Hideout":[
-      {
-        "act":1,
-        "level":20,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
+			]
+		}],
+		"Coastal Hideout": [{
+			"act": 1,
+			"level": 20,
+			"town": false,
+			"waypoint": true,
+			"bosses": [
 
-        ]
-      }
-    ],
-    "Overgrown Hideout":[
-      {
-        "act":1,
-        "level":20,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
+			]
+		}],
+		"Overgrown Hideout": [{
+			"act": 1,
+			"level": 20,
+			"town": false,
+			"waypoint": true,
+			"bosses": [
 
-        ]
-      }
-    ],
-    "Lush Hideout":[
-      {
-        "act":1,
-        "level":20,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
+			]
+		}],
+		"Lush Hideout": [{
+			"act": 1,
+			"level": 20,
+			"town": false,
+			"waypoint": true,
+			"bosses": [
 
-        ]
-      }
-    ],
-    "Battle-scarred Hideout":[
-      {
-        "act":1,
-        "level":20,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
+			]
+		}],
+		"Battle-scarred Hideout": [{
+			"act": 1,
+			"level": 20,
+			"town": false,
+			"waypoint": true,
+			"bosses": [
 
-        ]
-      }
-    ],
-    "Backstreet Hideout":[
-      {
-        "act":1,
-        "level":20,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
+			]
+		}],
+		"Backstreet Hideout": [{
+			"act": 1,
+			"level": 20,
+			"town": false,
+			"waypoint": true,
+			"bosses": [
 
-        ]
-      }
-    ],
-    "Immaculate Hideout":[
-      {
-        "act":1,
-        "level":20,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
+			]
+		}],
+		"Immaculate Hideout": [{
+			"act": 1,
+			"level": 20,
+			"town": false,
+			"waypoint": true,
+			"bosses": [
 
-        ]
-      }
-    ],
-    "Lioneye's Watch":[
-      {
-        "act":1,
-        "level":13,
-        "town":true,
-        "waypoint":true,
-        "bosses":[
+			]
+		}],
+		"Lioneye's Watch": [{
+				"act": 1,
+				"level": 13,
+				"town": true,
+				"waypoint": true,
+				"bosses": [
 
-        ]
-      },
-      {
-        "act":6,
-        "level":50,
-        "town":true,
-        "waypoint":true,
-        "bosses":[
+				]
+			},
+			{
+				"act": 6,
+				"level": 50,
+				"town": true,
+				"waypoint": true,
+				"bosses": [
 
-        ]
-      }
-    ],
-    "The Twilight Strand":[
-      {
-        "act":1,
-        "level":1,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Hillock"
-          }
-        ]
-      },
-      {
-        "act":6,
-        "level":45,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Rhys of Abram"
-          }
-        ]
-      }
-    ],
-    "The Coast":[
-      {
-        "act":1,
-        "level":2,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Fire Fury"
-          }
-        ]
-      },
-      {
-        "act":6,
-        "level":45,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
+				]
+			}
+		],
+		"The Twilight Strand": [{
+				"act": 1,
+				"level": 1,
+				"town": false,
+				"waypoint": false,
+				"bosses": [{
+					"name": "Hillock"
+				}]
+			},
+			{
+				"act": 6,
+				"level": 45,
+				"town": false,
+				"waypoint": false,
+				"bosses": [{
+					"name": "Rhys of Abram"
+				}]
+			}
+		],
+		"The Coast": [{
+				"act": 1,
+				"level": 2,
+				"town": false,
+				"waypoint": true,
+				"bosses": [{
+					"name": "Fire Fury"
+				}]
+			},
+			{
+				"act": 6,
+				"level": 45,
+				"town": false,
+				"waypoint": true,
+				"bosses": [
 
-        ]
-      }
-    ],
-    "The Tidal Island":[
-      {
-        "act":1,
-        "level":3,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Hailrake"
-          }
-        ]
-      },
-      {
-        "act":6,
-        "level":45,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Riptide"
-          }
-        ]
-      }
-    ],
-    "The Mud Flats":[
-      {
-        "act":1,
-        "level":4,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Oozeback Bloom"
-          }
-        ]
-      },
-      {
-        "act":6,
-        "level":46,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"The Dishonoured Queen"
-          },
-          {
-            "name":"Forgotten Warrior"
-          }
-        ]
-      }
-    ],
-    "The Fetid Pool":[
-      {
-        "act":1,
-        "level":5,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Kadavrus the Defiler"
-          }
-        ]
-      }
-    ],
-    "The Flooded Depths":[
-      {
-        "act":1,
-        "level":6,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"The Deep Dweller"
-          }
-        ]
-      }
-    ],
-    "The Submerged Passage":[
-      {
-        "act":1,
-        "level":5,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Brood Princess"
-          }
-        ]
-      }
-    ],
-    "The Ledge":[
-      {
-        "act":1,
-        "level":6,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Kuduku, the False God"
-          }
-        ]
-      }
-    ],
-    "The Climb":[
-      {
-        "act":1,
-        "level":7,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Ironpoint the Forsaken"
-          },
-          {
-            "name":"The Faun"
-          }
-        ]
-      }
-    ],
-    "The Lower Prison":[
-      {
-        "act":1,
-        "level":8,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Chatters"
-          }
-        ]
-      },
-      {
-        "act":6,
-        "level":47,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
+				]
+			}
+		],
+		"The Tidal Island": [{
+				"act": 1,
+				"level": 3,
+				"town": false,
+				"waypoint": false,
+				"bosses": [{
+					"name": "Hailrake"
+				}]
+			},
+			{
+				"act": 6,
+				"level": 45,
+				"town": false,
+				"waypoint": false,
+				"bosses": [{
+					"name": "Riptide"
+				}]
+			}
+		],
+		"The Mud Flats": [{
+				"act": 1,
+				"level": 4,
+				"town": false,
+				"waypoint": false,
+				"bosses": [{
+					"name": "Oozeback Bloom"
+				}]
+			},
+			{
+				"act": 6,
+				"level": 46,
+				"town": false,
+				"waypoint": false,
+				"bosses": [{
+						"name": "The Dishonoured Queen"
+					},
+					{
+						"name": "Forgotten Warrior"
+					}
+				]
+			}
+		],
+		"The Fetid Pool": [{
+			"act": 1,
+			"level": 5,
+			"town": false,
+			"waypoint": false,
+			"bosses": [{
+				"name": "Kadavrus the Defiler"
+			}]
+		}],
+		"The Flooded Depths": [{
+			"act": 1,
+			"level": 6,
+			"town": false,
+			"waypoint": false,
+			"bosses": [{
+				"name": "The Deep Dweller"
+			}]
+		}],
+		"The Submerged Passage": [{
+			"act": 1,
+			"level": 5,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+				"name": "Brood Princess"
+			}]
+		}],
+		"The Ledge": [{
+			"act": 1,
+			"level": 6,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+				"name": "Kuduku, the False God"
+			}]
+		}],
+		"The Climb": [{
+			"act": 1,
+			"level": 7,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+					"name": "Ironpoint the Forsaken"
+				},
+				{
+					"name": "The Faun"
+				}
+			]
+		}],
+		"The Lower Prison": [{
+				"act": 1,
+				"level": 8,
+				"town": false,
+				"waypoint": true,
+				"bosses": [{
+					"name": "Chatters"
+				}]
+			},
+			{
+				"act": 6,
+				"level": 47,
+				"town": false,
+				"waypoint": true,
+				"bosses": [
 
-        ]
-      }
-    ],
-    "The Upper Prison":[
-      {
-        "act":1,
-        "level":9,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Sawbones"
-          },
-          {
-            "name":"Brutus, Lord Incarcerator"
-          }
-        ]
-      }
-    ],
-    "Prisoner's Gate":[
-      {
-        "act":1,
-        "level":10,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Ungulath"
-          },
-          {
-            "name":"The Burning Menace"
-          }
-        ]
-      },
-      {
-        "act":6,
-        "level":47,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Abberath, the Cloven One"
-          }
-        ]
-      }
-    ],
-    "The Ship Graveyard":[
-      {
-        "act":1,
-        "level":11,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Captain Fairgraves"
-          }
-        ]
-      }
-    ],
-    "The Ship Graveyard Cave":[
-      {
-        "act":1,
-        "level":12,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Stranglecharm"
-          }
-        ]
-      }
-    ],
-    "The Cavern of Wrath":[
-      {
-        "act":1,
-        "level":12,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Amarissa, Daughter of Merveil"
-          }
-        ]
-      }
-    ],
-    "The Cavern of Anger":[
-      {
-        "act":1,
-        "level":13,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Ambrosia, Daughter of Merveil"
-          },
-          {
-            "name":"Merveil, the Siren"
-          }
-        ]
-      },
-      {
-        "act":6,
-        "level":49,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Brinecrack"
-          }
-        ]
-      }
-    ],
-    "The Forest Encampment":[
-      {
-        "act":2,
-        "level":23,
-        "town":true,
-        "waypoint":true,
-        "bosses":[
+				]
+			}
+		],
+		"The Upper Prison": [{
+			"act": 1,
+			"level": 9,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+					"name": "Sawbones"
+				},
+				{
+					"name": "Brutus, Lord Incarcerator"
+				}
+			]
+		}],
+		"Prisoner's Gate": [{
+				"act": 1,
+				"level": 10,
+				"town": false,
+				"waypoint": true,
+				"bosses": [{
+						"name": "Ungulath"
+					},
+					{
+						"name": "The Burning Menace"
+					}
+				]
+			},
+			{
+				"act": 6,
+				"level": 47,
+				"town": false,
+				"waypoint": true,
+				"bosses": [{
+					"name": "Abberath, the Cloven One"
+				}]
+			}
+		],
+		"The Ship Graveyard": [{
+			"act": 1,
+			"level": 11,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+				"name": "Captain Fairgraves"
+			}]
+		}],
+		"The Ship Graveyard Cave": [{
+			"act": 1,
+			"level": 12,
+			"town": false,
+			"waypoint": false,
+			"bosses": [{
+				"name": "Stranglecharm"
+			}]
+		}],
+		"The Cavern of Wrath": [{
+			"act": 1,
+			"level": 12,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+				"name": "Amarissa, Daughter of Merveil"
+			}]
+		}],
+		"The Cavern of Anger": [{
+				"act": 1,
+				"level": 13,
+				"town": false,
+				"waypoint": false,
+				"bosses": [{
+						"name": "Ambrosia, Daughter of Merveil"
+					},
+					{
+						"name": "Merveil, the Siren"
+					}
+				]
+			},
+			{
+				"act": 6,
+				"level": 49,
+				"town": false,
+				"waypoint": false,
+				"bosses": [{
+					"name": "Brinecrack"
+				}]
+			}
+		],
+		"The Forest Encampment": [{
+			"act": 2,
+			"level": 23,
+			"town": true,
+			"waypoint": true,
+			"bosses": [
 
-        ]
-      }
-    ],
-    "The Southern Forest":[
-      {
-        "act":2,
-        "level":13,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
+			]
+		}],
+		"The Southern Forest": [{
+				"act": 2,
+				"level": 13,
+				"town": false,
+				"waypoint": true,
+				"bosses": [
 
-        ]
-      },
-      {
-        "act":6,
-        "level":49,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Hollowskull, the Willing Host"
-          }
-        ]
-      }
-    ],
-    "The Old Fields":[
-      {
-        "act":2,
-        "level":14,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Gneiss"
-          }
-        ]
-      }
-    ],
-    "The Den":[
-      {
-        "act":2,
-        "level":15,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"The Great White Beast"
-          }
-        ]
-      },
-      {
-        "act":7,
-        "level":53,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"The Great White Bones"
-          },
-          {
-            "name":"The Bone Sculptor"
-          }
-        ]
-      }
-    ],
-    "The Crossroads":[
-      {
-        "act":2,
-        "level":15,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Bravalo"
-          }
-        ]
-      },
-      {
-        "act":7,
-        "level":51,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
+				]
+			},
+			{
+				"act": 6,
+				"level": 49,
+				"town": false,
+				"waypoint": true,
+				"bosses": [{
+					"name": "Hollowskull, the Willing Host"
+				}]
+			}
+		],
+		"The Old Fields": [{
+			"act": 2,
+			"level": 14,
+			"town": false,
+			"waypoint": false,
+			"bosses": [{
+				"name": "Gneiss"
+			}]
+		}],
+		"The Den": [{
+				"act": 2,
+				"level": 15,
+				"town": false,
+				"waypoint": false,
+				"bosses": [{
+					"name": "The Great White Beast"
+				}]
+			},
+			{
+				"act": 7,
+				"level": 53,
+				"town": false,
+				"waypoint": true,
+				"bosses": [{
+						"name": "The Great White Bones"
+					},
+					{
+						"name": "The Bone Sculptor"
+					}
+				]
+			}
+		],
+		"The Crossroads": [{
+				"act": 2,
+				"level": 15,
+				"town": false,
+				"waypoint": true,
+				"bosses": [{
+					"name": "Bravalo"
+				}]
+			},
+			{
+				"act": 7,
+				"level": 51,
+				"town": false,
+				"waypoint": true,
+				"bosses": [
 
-        ]
-      }
-    ],
-    "The Crypt Level 1":[
-      {
-        "act":2,
-        "level":17,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
+				]
+			}
+		],
+		"The Crypt Level 1": [{
+			"act": 2,
+			"level": 17,
+			"town": false,
+			"waypoint": true,
+			"bosses": [
 
-        ]
-      }
-    ],
-    "The Crypt Level 2":[
-      {
-        "act":2,
-        "level":18,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Archbishop Geofri the Abashed"
-          }
-        ]
-      }
-    ],
-    "The Chamber of Sins Level 1":[
-      {
-        "act":2,
-        "level":15,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Black Death"
-          }
-        ]
-      },
-      {
-        "act":7,
-        "level":52,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
+			]
+		}],
+		"The Crypt Level 2": [{
+			"act": 2,
+			"level": 18,
+			"town": false,
+			"waypoint": false,
+			"bosses": [{
+				"name": "Archbishop Geofri the Abashed"
+			}]
+		}],
+		"The Chamber of Sins Level 1": [{
+				"act": 2,
+				"level": 15,
+				"town": false,
+				"waypoint": true,
+				"bosses": [{
+					"name": "Black Death"
+				}]
+			},
+			{
+				"act": 7,
+				"level": 52,
+				"town": false,
+				"waypoint": true,
+				"bosses": [
 
-        ]
-      }
-    ],
-    "The Chamber of Sins Level 2":[
-      {
-        "act":2,
-        "level":16,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Fidelitas, the Mourning"
-          }
-        ]
-      },
-      {
-        "act":7,
-        "level":52,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Plague Retch"
-          }
-        ]
-      }
-    ],
-    "The Broken Bridge":[
-      {
-        "act":2,
-        "level":16,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Kraityn, Scarbearer"
-          }
-        ]
-      },
-      {
-        "act":7,
-        "level":50,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
+				]
+			}
+		],
+		"The Chamber of Sins Level 2": [{
+				"act": 2,
+				"level": 16,
+				"town": false,
+				"waypoint": false,
+				"bosses": [{
+					"name": "Fidelitas, the Mourning"
+				}]
+			},
+			{
+				"act": 7,
+				"level": 52,
+				"town": false,
+				"waypoint": false,
+				"bosses": [{
+					"name": "Plague Retch"
+				}]
+			}
+		],
+		"The Broken Bridge": [{
+				"act": 2,
+				"level": 16,
+				"town": false,
+				"waypoint": true,
+				"bosses": [{
+					"name": "Kraityn, Scarbearer"
+				}]
+			},
+			{
+				"act": 7,
+				"level": 50,
+				"town": false,
+				"waypoint": false,
+				"bosses": [
 
-        ]
-      }
-    ],
-    "The Riverways":[
-      {
-        "act":2,
-        "level":15,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Targa, Beast Poacher"
-          }
-        ]
-      },
-      {
-        "act":6,
-        "level":48,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"The Animal Pack"
-          }
-        ]
-      }
-    ],
-    "The Northern Forest":[
-      {
-        "act":2,
-        "level":21,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Seleslatha"
-          }
-        ]
-      },
-      {
-        "act":7,
-        "level":53,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Tunnelworm"
-          }
-        ]
-      }
-    ],
-    "The Western Forest":[
-      {
-        "act":2,
-        "level":17,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Alira Darktongue"
-          },
-          {
-            "name":"Captain Arteri"
-          }
-        ]
-      },
-      {
-        "act":6,
-        "level":48,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Defiled Proclamation"
-          }
-        ]
-      }
-    ],
-    "The Weaver's Chambers":[
-      {
-        "act":2,
-        "level":18,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"The Weaver"
-          }
-        ]
-      }
-    ],
-    "The Vaal Ruins":[
-      {
-        "act":2,
-        "level":20,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
+				]
+			}
+		],
+		"The Riverways": [{
+				"act": 2,
+				"level": 15,
+				"town": false,
+				"waypoint": true,
+				"bosses": [{
+					"name": "Targa, Beast Poacher"
+				}]
+			},
+			{
+				"act": 6,
+				"level": 48,
+				"town": false,
+				"waypoint": true,
+				"bosses": [{
+					"name": "The Animal Pack"
+				}]
+			}
+		],
+		"The Northern Forest": [{
+				"act": 2,
+				"level": 21,
+				"town": false,
+				"waypoint": true,
+				"bosses": [{
+					"name": "Seleslatha"
+				}]
+			},
+			{
+				"act": 7,
+				"level": 53,
+				"town": false,
+				"waypoint": true,
+				"bosses": [{
+					"name": "Tunnelworm"
+				}]
+			}
+		],
+		"The Western Forest": [{
+				"act": 2,
+				"level": 17,
+				"town": false,
+				"waypoint": true,
+				"bosses": [{
+						"name": "Alira Darktongue"
+					},
+					{
+						"name": "Captain Arteri"
+					}
+				]
+			},
+			{
+				"act": 6,
+				"level": 48,
+				"town": false,
+				"waypoint": true,
+				"bosses": [{
+					"name": "Defiled Proclamation"
+				}]
+			}
+		],
+		"The Weaver's Chambers": [{
+			"act": 2,
+			"level": 18,
+			"town": false,
+			"waypoint": false,
+			"bosses": [{
+				"name": "The Weaver"
+			}]
+		}],
+		"The Vaal Ruins": [{
+			"act": 2,
+			"level": 20,
+			"town": false,
+			"waypoint": false,
+			"bosses": [
 
-        ]
-      }
-    ],
-    "The Wetlands":[
-      {
-        "act":2,
-        "level":19,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Oak, Skullbreaker"
-          }
-        ]
-      },
-      {
-        "act":6,
-        "level":48,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Ryslatha, the Puppet Mistress"
-          }
-        ]
-      }
-    ],
-    "The Dread Thicket":[
-      {
-        "act":2,
-        "level":21,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Nadia the Soothing"
-          },
-          {
-            "name":"Aidan the Frenzied"
-          }
-        ]
-      },
-      {
-        "act":7,
-        "level":53,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Gruthkul, Mother of Despair"
-          },
-          {
-            "name":"The Dreadstone"
-          }
-        ]
-      }
-    ],
-    "The Caverns":[
-      {
-        "act":2,
-        "level":22,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Q'uru"
-          }
-        ]
-      }
-    ],
-    "The Ancient Pyramid":[
-      {
-        "act":2,
-        "level":23,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
+			]
+		}],
+		"The Wetlands": [{
+				"act": 2,
+				"level": 19,
+				"town": false,
+				"waypoint": true,
+				"bosses": [{
+					"name": "Oak, Skullbreaker"
+				}]
+			},
+			{
+				"act": 6,
+				"level": 48,
+				"town": false,
+				"waypoint": false,
+				"bosses": [{
+					"name": "Ryslatha, the Puppet Mistress"
+				}]
+			}
+		],
+		"The Dread Thicket": [{
+				"act": 2,
+				"level": 21,
+				"town": false,
+				"waypoint": false,
+				"bosses": [{
+						"name": "Nadia the Soothing"
+					},
+					{
+						"name": "Aidan the Frenzied"
+					}
+				]
+			},
+			{
+				"act": 7,
+				"level": 53,
+				"town": false,
+				"waypoint": false,
+				"bosses": [{
+						"name": "Gruthkul, Mother of Despair"
+					},
+					{
+						"name": "The Dreadstone"
+					}
+				]
+			}
+		],
+		"The Caverns": [{
+			"act": 2,
+			"level": 22,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+				"name": "Q'uru"
+			}]
+		}],
+		"The Ancient Pyramid": [{
+			"act": 2,
+			"level": 23,
+			"town": false,
+			"waypoint": false,
+			"bosses": [
 
-        ]
-      }
-    ],
-    "The Fellshrine Ruins":[
-      {
-        "act":2,
-        "level":16,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Soulmourn"
-          }
-        ]
-      },
-      {
-        "act":7,
-        "level":51,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Bundle of Woe"
-          }
-        ]
-      }
-    ],
-    "The Sarn Encampment":[
-      {
-        "act":3,
-        "level":33,
-        "town":true,
-        "waypoint":true,
-        "bosses":[
+			]
+		}],
+		"The Fellshrine Ruins": [{
+				"act": 2,
+				"level": 16,
+				"town": false,
+				"waypoint": false,
+				"bosses": [{
+					"name": "Soulmourn"
+				}]
+			},
+			{
+				"act": 7,
+				"level": 51,
+				"town": false,
+				"waypoint": false,
+				"bosses": [{
+					"name": "Bundle of Woe"
+				}]
+			}
+		],
+		"The Sarn Encampment": [{
+				"act": 3,
+				"level": 33,
+				"town": true,
+				"waypoint": true,
+				"bosses": [
 
-        ]
-      },
-      {
-        "act":8,
-        "level":60,
-        "town":true,
-        "waypoint":true,
-        "bosses":[
+				]
+			},
+			{
+				"act": 8,
+				"level": 60,
+				"town": true,
+				"waypoint": true,
+				"bosses": [
 
-        ]
-      }
-    ],
-    "The City of Sarn":[
-      {
-        "act":3,
-        "level":23,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Guard Captain"
-          }
-        ]
-      }
-    ],
-    "The Slums":[
-      {
-        "act":3,
-        "level":24,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Perpetus"
-          }
-        ]
-      }
-    ],
-    "The Crematorium":[
-      {
-        "act":3,
-        "level":25,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Hatebeat"
-          },
-          {
-            "name":"Piety"
-          }
-        ]
-      }
-    ],
-    "The Marketplace":[
-      {
-        "act":3,
-        "level":26,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Marceus the Defaced"
-          }
-        ]
-      }
-    ],
-    "The Catacombs":[
-      {
-        "act":3,
-        "level":27,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
+				]
+			}
+		],
+		"The City of Sarn": [{
+			"act": 3,
+			"level": 23,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+				"name": "Guard Captain"
+			}]
+		}],
+		"The Slums": [{
+			"act": 3,
+			"level": 24,
+			"town": false,
+			"waypoint": false,
+			"bosses": [{
+				"name": "Perpetus"
+			}]
+		}],
+		"The Crematorium": [{
+			"act": 3,
+			"level": 25,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+					"name": "Hatebeat"
+				},
+				{
+					"name": "Piety"
+				}
+			]
+		}],
+		"The Marketplace": [{
+			"act": 3,
+			"level": 26,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+				"name": "Marceus the Defaced"
+			}]
+		}],
+		"The Catacombs": [{
+			"act": 3,
+			"level": 27,
+			"town": false,
+			"waypoint": false,
+			"bosses": [
 
-        ]
-      }
-    ],
-    "The Battlefront":[
-      {
-        "act":3,
-        "level":27,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Captain Aurelianus"
-          }
-        ]
-      }
-    ],
-    "The Solaris Temple Level 1":[
-      {
-        "act":3,
-        "level":27,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"The Infernal Seal"
-          },
-          {
-            "name":"The Voltaic Seal"
-          }
-        ]
-      },
-      {
-        "act":8,
-        "level":59,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
+			]
+		}],
+		"The Battlefront": [{
+			"act": 3,
+			"level": 27,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+				"name": "Captain Aurelianus"
+			}]
+		}],
+		"The Solaris Temple Level 1": [{
+				"act": 3,
+				"level": 27,
+				"town": false,
+				"waypoint": true,
+				"bosses": [{
+						"name": "The Infernal Seal"
+					},
+					{
+						"name": "The Voltaic Seal"
+					}
+				]
+			},
+			{
+				"act": 8,
+				"level": 59,
+				"town": false,
+				"waypoint": true,
+				"bosses": [
 
-        ]
-      }
-    ],
-    "The Solaris Temple Level 2":[
-      {
-        "act":3,
-        "level":28,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Banner of Passion"
-          },
-          {
-            "name":"Banner of Knowledge"
-          },
-          {
-            "name":"Banner of Action"
-          }
-        ]
-      },
-      {
-        "act":8,
-        "level":59,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Dawn, Harbinger of Solaris"
-          }
-        ]
-      }
-    ],
-    "The Docks":[
-      {
-        "act":3,
-        "level":29,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"The Shipyard Terror"
-          }
-        ]
-      }
-    ],
-    "The Sewers":[
-      {
-        "act":3,
-        "level":26,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Gloomglut"
-          }
-        ]
-      }
-    ],
-    "The Ebony Barracks":[
-      {
-        "act":3,
-        "level":29,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"General Gravicius"
-          }
-        ]
-      }
-    ],
-    "The Lunaris Temple Level 1":[
-      {
-        "act":3,
-        "level":29,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Fleshrend, Grand Inquisitor"
-          },
-          {
-            "name":"Kole"
-          }
-        ]
-      },
-      {
-        "act":8,
-        "level":59,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
+				]
+			}
+		],
+		"The Solaris Temple Level 2": [{
+				"act": 3,
+				"level": 28,
+				"town": false,
+				"waypoint": true,
+				"bosses": [{
+						"name": "Banner of Passion"
+					},
+					{
+						"name": "Banner of Knowledge"
+					},
+					{
+						"name": "Banner of Action"
+					}
+				]
+			},
+			{
+				"act": 8,
+				"level": 59,
+				"town": false,
+				"waypoint": false,
+				"bosses": [{
+					"name": "Dawn, Harbinger of Solaris"
+				}]
+			}
+		],
+		"The Docks": [{
+			"act": 3,
+			"level": 29,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+				"name": "The Shipyard Terror"
+			}]
+		}],
+		"The Sewers": [{
+			"act": 3,
+			"level": 26,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+				"name": "Gloomglut"
+			}]
+		}],
+		"The Ebony Barracks": [{
+			"act": 3,
+			"level": 29,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+				"name": "General Gravicius"
+			}]
+		}],
+		"The Lunaris Temple Level 1": [{
+				"act": 3,
+				"level": 29,
+				"town": false,
+				"waypoint": true,
+				"bosses": [{
+						"name": "Fleshrend, Grand Inquisitor"
+					},
+					{
+						"name": "Kole"
+					}
+				]
+			},
+			{
+				"act": 8,
+				"level": 59,
+				"town": false,
+				"waypoint": true,
+				"bosses": [
 
-        ]
-      }
-    ],
-    "The Lunaris Temple Level 2":[
-      {
-        "act":3,
-        "level":30,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Piety"
-          },
-          {
-            "name":"Spinecrack"
-          }
-        ]
-      },
-      {
-        "act":8,
-        "level":59,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Dusk, Harbinger of Lunaris"
-          }
-        ]
-      }
-    ],
-    "The Imperial Gardens":[
-      {
-        "act":3,
-        "level":30,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Thistlesage"
-          },
-          {
-            "name":"The Conqueror Wurm"
-          }
-        ]
-      }
-    ],
-    "The Library":[
-      {
-        "act":3,
-        "level":30,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
+				]
+			}
+		],
+		"The Lunaris Temple Level 2": [{
+				"act": 3,
+				"level": 30,
+				"town": false,
+				"waypoint": false,
+				"bosses": [{
+						"name": "Piety"
+					},
+					{
+						"name": "Spinecrack"
+					}
+				]
+			},
+			{
+				"act": 8,
+				"level": 59,
+				"town": false,
+				"waypoint": false,
+				"bosses": [{
+					"name": "Dusk, Harbinger of Lunaris"
+				}]
+			}
+		],
+		"The Imperial Gardens": [{
+			"act": 3,
+			"level": 30,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+					"name": "Thistlesage"
+				},
+				{
+					"name": "The Conqueror Wurm"
+				}
+			]
+		}],
+		"The Library": [{
+			"act": 3,
+			"level": 30,
+			"town": false,
+			"waypoint": true,
+			"bosses": [
 
-        ]
-      }
-    ],
-    "The Archives":[
-      {
-        "act":3,
-        "level":31,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Trinian, Intellectus Prime"
-          }
-        ]
-      }
-    ],
-    "The Sceptre of God":[
-      {
-        "act":3,
-        "level":32,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Caliga, Imperatrix"
-          }
-        ]
-      }
-    ],
-    "The Upper Sceptre of God":[
-      {
-        "act":3,
-        "level":33,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Paradisae Venenum"
-          },
-          {
-            "name":"Dominus, High Templar"
-          },
-          {
-            "name":"Draconarius Wilhelm Flamebrand"
-          },
-          {
-            "name":"Imperator Stantinus Bitterblade"
-          },
-          {
-            "name":"Compulsor Octavia Sparkfist"
-          }
-        ]
-      }
-    ],
-    "Highgate":[
-      {
-        "act":4,
-        "level":40,
-        "town":true,
-        "waypoint":true,
-        "bosses":[
+			]
+		}],
+		"The Archives": [{
+			"act": 3,
+			"level": 31,
+			"town": false,
+			"waypoint": false,
+			"bosses": [{
+				"name": "Trinian, Intellectus Prime"
+			}]
+		}],
+		"The Sceptre of God": [{
+			"act": 3,
+			"level": 32,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+				"name": "Caliga, Imperatrix"
+			}]
+		}],
+		"The Upper Sceptre of God": [{
+			"act": 3,
+			"level": 33,
+			"town": false,
+			"waypoint": false,
+			"bosses": [{
+					"name": "Paradisae Venenum"
+				},
+				{
+					"name": "Dominus, High Templar"
+				},
+				{
+					"name": "Draconarius Wilhelm Flamebrand"
+				},
+				{
+					"name": "Imperator Stantinus Bitterblade"
+				},
+				{
+					"name": "Compulsor Octavia Sparkfist"
+				}
+			]
+		}],
+		"Highgate": [{
+				"act": 4,
+				"level": 40,
+				"town": true,
+				"waypoint": true,
+				"bosses": [
 
-        ]
-      },
-      {
-        "act":9,
-        "level":67,
-        "town":true,
-        "waypoint":true,
-        "bosses":[
+				]
+			},
+			{
+				"act": 9,
+				"level": 67,
+				"town": true,
+				"waypoint": true,
+				"bosses": [
 
-        ]
-      }
-    ],
-    "The Aqueduct":[
-      {
-        "act":4,
-        "level":33,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"The Hundred Foot Shadow"
-          }
-        ]
-      }
-    ],
-    "The Dried Lake":[
-      {
-        "act":4,
-        "level":34,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Voll, Emperor of Purity"
-          },
-          {
-            "name":"Nightwane"
-          }
-        ]
-      }
-    ],
-    "The Mines Level 1":[
-      {
-        "act":4,
-        "level":34,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Pikerivet"
-          },
-          {
-            "name":"Voidscream"
-          }
-        ]
-      }
-    ],
-    "The Mines Level 2":[
-      {
-        "act":4,
-        "level":35,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Hammerstorm"
-          },
-          {
-            "name":"Voidscream"
-          },
-          {
-            "name":"Pikerivet"
-          },
-          {
-            "name":"The Burning Man"
-          }
-        ]
-      }
-    ],
-    "The Crystal Veins":[
-      {
-        "act":4,
-        "level":36,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"The Burning Man"
-          },
-          {
-            "name":"Hammerstorm"
-          }
-        ]
-      }
-    ],
-    "Kaom's Dream":[
-      {
-        "act":4,
-        "level":37,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Torchoak Grove"
-          },
-          {
-            "name":"Triskeriaki"
-          }
-        ]
-      }
-    ],
-    "Kaom's Stronghold":[
-      {
-        "act":4,
-        "level":38,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"King Kaom"
-          }
-        ]
-      }
-    ],
-    "Daresso's Dream":[
-      {
-        "act":4,
-        "level":37,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Barkhul"
-          },
-          {
-            "name":"Eyepecker"
-          },
-          {
-            "name":"Steelchaw"
-          }
-        ]
-      }
-    ],
-    "The Grand Arena":[
-      {
-        "act":4,
-        "level":38,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Daresso, King of Swords"
-          },
-          {
-            "name":"Rudiarius Felix"
-          },
-          {
-            "name":"Mevion"
-          },
-          {
-            "name":"Dimachaeri Cassius"
-          }
-        ]
-      }
-    ],
-    "The Belly of the Beast Level 1":[
-      {
-        "act":4,
-        "level":38,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"The Bone Queen"
-          }
-        ]
-      }
-    ],
-    "The Belly of the Beast Level 2":[
-      {
-        "act":4,
-        "level":39,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Piety, the Abomination"
-          }
-        ]
-      }
-    ],
-    "The Harvest":[
-      {
-        "act":4,
-        "level":40,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Malachai, The Nightmare"
-          },
-          {
-            "name":"Doedre Darktongue"
-          },
-          {
-            "name":"Maligaro, The Inquisitor"
-          },
-          {
-            "name":"Shavronne of Umbra"
-          }
-        ]
-      }
-    ],
-    "The Ascent":[
-      {
-        "act":4,
-        "level":40,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"The White Death"
-          }
-        ]
-      }
-    ],
-    "Overseer's Tower":[
-      {
-        "act":5,
-        "level":45,
-        "town":true,
-        "waypoint":true,
-        "bosses":[
+				]
+			}
+		],
+		"The Aqueduct": [{
+			"act": 4,
+			"level": 33,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+				"name": "The Hundred Foot Shadow"
+			}]
+		}],
+		"The Dried Lake": [{
+			"act": 4,
+			"level": 34,
+			"town": false,
+			"waypoint": false,
+			"bosses": [{
+					"name": "Voll, Emperor of Purity"
+				},
+				{
+					"name": "Nightwane"
+				}
+			]
+		}],
+		"The Mines Level 1": [{
+			"act": 4,
+			"level": 34,
+			"town": false,
+			"waypoint": false,
+			"bosses": [{
+					"name": "Pikerivet"
+				},
+				{
+					"name": "Voidscream"
+				}
+			]
+		}],
+		"The Mines Level 2": [{
+			"act": 4,
+			"level": 35,
+			"town": false,
+			"waypoint": false,
+			"bosses": [{
+					"name": "Hammerstorm"
+				},
+				{
+					"name": "Voidscream"
+				},
+				{
+					"name": "Pikerivet"
+				},
+				{
+					"name": "The Burning Man"
+				}
+			]
+		}],
+		"The Crystal Veins": [{
+			"act": 4,
+			"level": 36,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+					"name": "The Burning Man"
+				},
+				{
+					"name": "Hammerstorm"
+				}
+			]
+		}],
+		"Kaom's Dream": [{
+			"act": 4,
+			"level": 37,
+			"town": false,
+			"waypoint": false,
+			"bosses": [{
+					"name": "Torchoak Grove"
+				},
+				{
+					"name": "Triskeriaki"
+				}
+			]
+		}],
+		"Kaom's Stronghold": [{
+			"act": 4,
+			"level": 38,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+				"name": "King Kaom"
+			}]
+		}],
+		"Daresso's Dream": [{
+			"act": 4,
+			"level": 37,
+			"town": false,
+			"waypoint": false,
+			"bosses": [{
+					"name": "Barkhul"
+				},
+				{
+					"name": "Eyepecker"
+				},
+				{
+					"name": "Steelchaw"
+				}
+			]
+		}],
+		"The Grand Arena": [{
+			"act": 4,
+			"level": 38,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+					"name": "Daresso, King of Swords"
+				},
+				{
+					"name": "Rudiarius Felix"
+				},
+				{
+					"name": "Mevion"
+				},
+				{
+					"name": "Dimachaeri Cassius"
+				}
+			]
+		}],
+		"The Belly of the Beast Level 1": [{
+			"act": 4,
+			"level": 38,
+			"town": false,
+			"waypoint": false,
+			"bosses": [{
+				"name": "The Bone Queen"
+			}]
+		}],
+		"The Belly of the Beast Level 2": [{
+			"act": 4,
+			"level": 39,
+			"town": false,
+			"waypoint": false,
+			"bosses": [{
+				"name": "Piety, the Abomination"
+			}]
+		}],
+		"The Harvest": [{
+			"act": 4,
+			"level": 40,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+					"name": "Malachai, The Nightmare"
+				},
+				{
+					"name": "Doedre Darktongue"
+				},
+				{
+					"name": "Maligaro, The Inquisitor"
+				},
+				{
+					"name": "Shavronne of Umbra"
+				}
+			]
+		}],
+		"The Ascent": [{
+			"act": 4,
+			"level": 40,
+			"town": false,
+			"waypoint": false,
+			"bosses": [{
+				"name": "The White Death"
+			}]
+		}],
+		"Overseer's Tower": [{
+			"act": 5,
+			"level": 45,
+			"town": true,
+			"waypoint": true,
+			"bosses": [
 
-        ]
-      }
-    ],
-    "The Slave Pens":[
-      {
-        "act":5,
-        "level":41,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Overseer Krow"
-          }
-        ]
-      }
-    ],
-    "The Control Blocks":[
-      {
-        "act":5,
-        "level":41,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Justicar Casticus"
-          }
-        ]
-      },
-      {
-        "act":10,
-        "level":66,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Vilenta"
-          }
-        ]
-      }
-    ],
-    "Oriath Square":[
-      {
-        "act":5,
-        "level":42,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"The Matriarch"
-          },
-          {
-            "name":"Oriath Enforcer"
-          }
-        ]
-      }
-    ],
-    "The Ruined Square":[
-      {
-        "act":5,
-        "level":44,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Utula, Stone and Steel"
-          },
-          {
-            "name":"The Risen Matriarch"
-          }
-        ]
-      }
-    ],
-    "The Templar Courts":[
-      {
-        "act":5,
-        "level":42,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
+			]
+		}],
+		"The Slave Pens": [{
+			"act": 5,
+			"level": 41,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+				"name": "Overseer Krow"
+			}]
+		}],
+		"The Control Blocks": [{
+				"act": 5,
+				"level": 41,
+				"town": false,
+				"waypoint": false,
+				"bosses": [{
+					"name": "Justicar Casticus"
+				}]
+			},
+			{
+				"act": 10,
+				"level": 66,
+				"town": false,
+				"waypoint": true,
+				"bosses": [{
+					"name": "Vilenta"
+				}]
+			}
+		],
+		"Oriath Square": [{
+			"act": 5,
+			"level": 42,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+					"name": "The Matriarch"
+				},
+				{
+					"name": "Oriath Enforcer"
+				}
+			]
+		}],
+		"The Ruined Square": [{
+			"act": 5,
+			"level": 44,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+					"name": "Utula, Stone and Steel"
+				},
+				{
+					"name": "The Risen Matriarch"
+				}
+			]
+		}],
+		"The Templar Courts": [{
+			"act": 5,
+			"level": 42,
+			"town": false,
+			"waypoint": true,
+			"bosses": [
 
-        ]
-      }
-    ],
-    "The Torched Courts":[
-      {
-        "act":5,
-        "level":44,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Cato, Scholar of Light"
-          }
-        ]
-      },
-      {
-        "act":10,
-        "level":65,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
+			]
+		}],
+		"The Torched Courts": [{
+				"act": 5,
+				"level": 44,
+				"town": false,
+				"waypoint": false,
+				"bosses": [{
+					"name": "Cato, Scholar of Light"
+				}]
+			},
+			{
+				"act": 10,
+				"level": 65,
+				"town": false,
+				"waypoint": false,
+				"bosses": [
 
-        ]
-      }
-    ],
-    "The Chamber of Innocence":[
-      {
-        "act":5,
-        "level":43,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"High Templar Avarius"
-          }
-        ]
-      }
-    ],
-    "The Ossuary":[
-      {
-        "act":5,
-        "level":44,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
+				]
+			}
+		],
+		"The Chamber of Innocence": [{
+			"act": 5,
+			"level": 43,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+				"name": "High Templar Avarius"
+			}]
+		}],
+		"The Ossuary": [{
+				"act": 5,
+				"level": 44,
+				"town": false,
+				"waypoint": false,
+				"bosses": [
 
-        ]
-      },
-      {
-        "act":10,
-        "level":67,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
+				]
+			},
+			{
+				"act": 10,
+				"level": 67,
+				"town": false,
+				"waypoint": false,
+				"bosses": [
 
-        ]
-      }
-    ],
-    "The Reliquary":[
-      {
-        "act":5,
-        "level":44,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
+				]
+			}
+		],
+		"The Reliquary": [{
+				"act": 5,
+				"level": 44,
+				"town": false,
+				"waypoint": true,
+				"bosses": [
 
-        ]
-      },
-      {
-        "act":10,
-        "level":67,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
+				]
+			},
+			{
+				"act": 10,
+				"level": 67,
+				"town": false,
+				"waypoint": true,
+				"bosses": [
 
-        ]
-      }
-    ],
-    "The Cathedral Rooftop":[
-      {
-        "act":5,
-        "level":45,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Kitava, the Insatiable"
-          }
-        ]
-      },
-      {
-        "act":10,
-        "level":64,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
+				]
+			}
+		],
+		"The Cathedral Rooftop": [{
+				"act": 5,
+				"level": 45,
+				"town": false,
+				"waypoint": true,
+				"bosses": [{
+					"name": "Kitava, the Insatiable"
+				}]
+			},
+			{
+				"act": 10,
+				"level": 64,
+				"town": false,
+				"waypoint": false,
+				"bosses": [
 
-        ]
-      }
-    ],
-    "The Karui Fortress":[
-      {
-        "act":6,
-        "level":46,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Tukohama, Karui God of War"
-          }
-        ]
-      }
-    ],
-    "The Ridge":[
-      {
-        "act":6,
-        "level":46,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Fleetfreak"
-          }
-        ]
-      }
-    ],
-    "Shavronne's Tower":[
-      {
-        "act":6,
-        "level":47,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Shavronne the Returned"
-          },
-          {
-            "name":"Reassembled Brutus"
-          }
-        ]
-      }
-    ],
-    "The Beacon":[
-      {
-        "act":6,
-        "level":49,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
+				]
+			}
+		],
+		"The Karui Fortress": [{
+			"act": 6,
+			"level": 46,
+			"town": false,
+			"waypoint": false,
+			"bosses": [{
+				"name": "Tukohama, Karui God of War"
+			}]
+		}],
+		"The Ridge": [{
+			"act": 6,
+			"level": 46,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+				"name": "Fleetfreak"
+			}]
+		}],
+		"Shavronne's Tower": [{
+			"act": 6,
+			"level": 47,
+			"town": false,
+			"waypoint": false,
+			"bosses": [{
+					"name": "Shavronne the Returned"
+				},
+				{
+					"name": "Reassembled Brutus"
+				}
+			]
+		}],
+		"The Beacon": [{
+			"act": 6,
+			"level": 49,
+			"town": false,
+			"waypoint": true,
+			"bosses": [
 
-        ]
-      }
-    ],
-    "The Brine King's Reef":[
-      {
-        "act":6,
-        "level":50,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Tsoagoth, The Brine King"
-          }
-        ]
-      }
-    ],
-    "The Bridge Encampment":[
-      {
-        "act":7,
-        "level":55,
-        "town":true,
-        "waypoint":true,
-        "bosses":[
+			]
+		}],
+		"The Brine King's Reef": [{
+			"act": 6,
+			"level": 50,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+				"name": "Tsoagoth, The Brine King"
+			}]
+		}],
+		"The Bridge Encampment": [{
+			"act": 7,
+			"level": 55,
+			"town": true,
+			"waypoint": true,
+			"bosses": [
 
-        ]
-      }
-    ],
-    "The Crypt":[
-      {
-        "act":7,
-        "level":51,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
+			]
+		}],
+		"The Crypt": [{
+			"act": 7,
+			"level": 51,
+			"town": false,
+			"waypoint": true,
+			"bosses": [
 
-        ]
-      }
-    ],
-    "Maligaro's Sanctum":[
-      {
-        "act":7,
-        "level":52,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Maligaro, the Artist"
-          },
-          {
-            "name":"Black Death, Pain Unending"
-          },
-          {
-            "name":"Fidelitas, Loyalty Undying"
-          }
-        ]
-      }
-    ],
-    "The Ashen Fields":[
-      {
-        "act":7,
-        "level":53,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Greust, Lord of the Forest"
-          },
-          {
-            "name":"Oak"
-          },
-          {
-            "name":"Alira"
-          },
-          {
-            "name":"Kraityn"
-          }
-        ]
-      }
-    ],
-    "The Causeway":[
-      {
-        "act":7,
-        "level":54,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
+			]
+		}],
+		"Maligaro's Sanctum": [{
+			"act": 7,
+			"level": 52,
+			"town": false,
+			"waypoint": false,
+			"bosses": [{
+					"name": "Maligaro, the Artist"
+				},
+				{
+					"name": "Black Death, Pain Unending"
+				},
+				{
+					"name": "Fidelitas, Loyalty Undying"
+				}
+			]
+		}],
+		"The Ashen Fields": [{
+			"act": 7,
+			"level": 53,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+					"name": "Greust, Lord of the Forest"
+				},
+				{
+					"name": "Oak"
+				},
+				{
+					"name": "Alira"
+				},
+				{
+					"name": "Kraityn"
+				}
+			]
+		}],
+		"The Causeway": [{
+			"act": 7,
+			"level": 54,
+			"town": false,
+			"waypoint": true,
+			"bosses": [
 
-        ]
-      }
-    ],
-    "The Vaal City":[
-      {
-        "act":7,
-        "level":54,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
+			]
+		}],
+		"The Vaal City": [{
+			"act": 7,
+			"level": 54,
+			"town": false,
+			"waypoint": true,
+			"bosses": [
 
-        ]
-      }
-    ],
-    "The Temple of Decay Level 1":[
-      {
-        "act":7,
-        "level":54,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Blightblade"
-          }
-        ]
-      }
-    ],
-    "The Temple of Decay Level 2":[
-      {
-        "act":7,
-        "level":55,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Arakaali, Spinner of Shadows"
-          }
-        ]
-      }
-    ],
-    "The Sarn Ramparts":[
-      {
-        "act":8,
-        "level":55,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
+			]
+		}],
+		"The Temple of Decay Level 1": [{
+			"act": 7,
+			"level": 54,
+			"town": false,
+			"waypoint": false,
+			"bosses": [{
+				"name": "Blightblade"
+			}]
+		}],
+		"The Temple of Decay Level 2": [{
+			"act": 7,
+			"level": 55,
+			"town": false,
+			"waypoint": false,
+			"bosses": [{
+				"name": "Arakaali, Spinner of Shadows"
+			}]
+		}],
+		"The Sarn Ramparts": [{
+			"act": 8,
+			"level": 55,
+			"town": false,
+			"waypoint": true,
+			"bosses": [
 
-        ]
-      }
-    ],
-    "The Toxic Conduits":[
-      {
-        "act":8,
-        "level":56,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Lingering Aberration"
-          }
-        ]
-      }
-    ],
-    "Doedre's Cesspool":[
-      {
-        "act":8,
-        "level":56,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Doedre the Vile"
-          }
-        ]
-      }
-    ],
-    "The Grand Promenade":[
-      {
-        "act":8,
-        "level":56,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Ondar, the Betrayer"
-          }
-        ]
-      }
-    ],
-    "The High Gardens":[
-      {
-        "act":8,
-        "level":58,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Yugul, Reflection of Terror"
-          }
-        ]
-      }
-    ],
-    "The Bath House":[
-      {
-        "act":8,
-        "level":57,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Hector Titucius, Eternal Servant"
-          }
-        ]
-      }
-    ],
-    "The Lunaris Concourse":[
-      {
-        "act":8,
-        "level":58,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Nightbringer Lucius"
-          }
-        ]
-      }
-    ],
-    "The Quay":[
-      {
-        "act":8,
-        "level":57,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Tolman"
-          }
-        ]
-      }
-    ],
-    "The Grain Gate":[
-      {
-        "act":8,
-        "level":57,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Gemling Legionnaire"
-          },
-          {
-            "name":"Gemling Captain"
-          }
-        ]
-      }
-    ],
-    "The Imperial Fields":[
-      {
-        "act":8,
-        "level":58,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Effigy of Fear"
-          }
-        ]
-      }
-    ],
-    "The Solaris Concourse":[
-      {
-        "act":8,
-        "level":58,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
+			]
+		}],
+		"The Toxic Conduits": [{
+			"act": 8,
+			"level": 56,
+			"town": false,
+			"waypoint": false,
+			"bosses": [{
+				"name": "Lingering Aberration"
+			}]
+		}],
+		"Doedre's Cesspool": [{
+			"act": 8,
+			"level": 56,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+				"name": "Doedre the Vile"
+			}]
+		}],
+		"The Grand Promenade": [{
+			"act": 8,
+			"level": 56,
+			"town": false,
+			"waypoint": false,
+			"bosses": [{
+				"name": "Ondar, the Betrayer"
+			}]
+		}],
+		"The High Gardens": [{
+			"act": 8,
+			"level": 58,
+			"town": false,
+			"waypoint": false,
+			"bosses": [{
+				"name": "Yugul, Reflection of Terror"
+			}]
+		}],
+		"The Bath House": [{
+			"act": 8,
+			"level": 57,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+				"name": "Hector Titucius, Eternal Servant"
+			}]
+		}],
+		"The Lunaris Concourse": [{
+			"act": 8,
+			"level": 58,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+				"name": "Nightbringer Lucius"
+			}]
+		}],
+		"The Quay": [{
+			"act": 8,
+			"level": 57,
+			"town": false,
+			"waypoint": false,
+			"bosses": [{
+				"name": "Tolman"
+			}]
+		}],
+		"The Grain Gate": [{
+			"act": 8,
+			"level": 57,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+					"name": "Gemling Legionnaire"
+				},
+				{
+					"name": "Gemling Captain"
+				}
+			]
+		}],
+		"The Imperial Fields": [{
+			"act": 8,
+			"level": 58,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+				"name": "Effigy of Fear"
+			}]
+		}],
+		"The Solaris Concourse": [{
+			"act": 8,
+			"level": 58,
+			"town": false,
+			"waypoint": true,
+			"bosses": [
 
-        ]
-      }
-    ],
-    "The Harbour Bridge":[
-      {
-        "act":8,
-        "level":60,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Lunaris, Eternal Moon"
-          },
-          {
-            "name":"Solaris, Eternal Sun"
-          }
-        ]
-      }
-    ],
-    "The Blood Aqueduct":[
-      {
-        "act":9,
-        "level":61,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
+			]
+		}],
+		"The Harbour Bridge": [{
+			"act": 8,
+			"level": 60,
+			"town": false,
+			"waypoint": false,
+			"bosses": [{
+					"name": "Lunaris, Eternal Moon"
+				},
+				{
+					"name": "Solaris, Eternal Sun"
+				}
+			]
+		}],
+		"The Blood Aqueduct": [{
+			"act": 9,
+			"level": 61,
+			"town": false,
+			"waypoint": true,
+			"bosses": [
 
-        ]
-      }
-    ],
-    "The Descent":[
-      {
-        "act":9,
-        "level":61,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
+			]
+		}],
+		"The Descent": [{
+			"act": 9,
+			"level": 61,
+			"town": false,
+			"waypoint": false,
+			"bosses": [
 
-        ]
-      }
-    ],
-    "The Vastiri Desert":[
-      {
-        "act":9,
-        "level":61,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
+			]
+		}],
+		"The Vastiri Desert": [{
+			"act": 9,
+			"level": 61,
+			"town": false,
+			"waypoint": true,
+			"bosses": [
 
-        ]
-      }
-    ],
-    "The Oasis":[
-      {
-        "act":9,
-        "level":61,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Shakari, Queen of the Sands"
-          }
-        ]
-      }
-    ],
-    "The Foothills":[
-      {
-        "act":9,
-        "level":62,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Boulderback"
-          }
-        ]
-      }
-    ],
-    "The Boiling Lake":[
-      {
-        "act":9,
-        "level":62,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"The Basilisk"
-          }
-        ]
-      }
-    ],
-    "The Tunnel":[
-      {
-        "act":9,
-        "level":62,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
+			]
+		}],
+		"The Oasis": [{
+			"act": 9,
+			"level": 61,
+			"town": false,
+			"waypoint": false,
+			"bosses": [{
+				"name": "Shakari, Queen of the Sands"
+			}]
+		}],
+		"The Foothills": [{
+			"act": 9,
+			"level": 62,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+				"name": "Boulderback"
+			}]
+		}],
+		"The Boiling Lake": [{
+			"act": 9,
+			"level": 62,
+			"town": false,
+			"waypoint": false,
+			"bosses": [{
+				"name": "The Basilisk"
+			}]
+		}],
+		"The Tunnel": [{
+			"act": 9,
+			"level": 62,
+			"town": false,
+			"waypoint": true,
+			"bosses": [
 
-        ]
-      }
-    ],
-    "The Quarry":[
-      {
-        "act":9,
-        "level":63,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Garukhan, Queen of the Winds"
-          }
-        ]
-      }
-    ],
-    "The Refinery":[
-      {
-        "act":9,
-        "level":63,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"General Adus"
-          }
-        ]
-      }
-    ],
-    "The Belly of the Beast":[
-      {
-        "act":9,
-        "level":63,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Droolmaw"
-          }
-        ]
-      }
-    ],
-    "The Rotting Core":[
-      {
-        "act":9,
-        "level":64,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"The Depraved Trinity"
-          },
-          {
-            "name":"Doedre, Darksoul"
-          },
-          {
-            "name":"Maligaro, The Broken"
-          },
-          {
-            "name":"Shavronne, Unbound"
-          }
-        ]
-      }
-    ],
-    "Oriath Docks":[
-      {
-        "act":10,
-        "level":69,
-        "town":true,
-        "waypoint":true,
-        "bosses":[
+			]
+		}],
+		"The Quarry": [{
+			"act": 9,
+			"level": 63,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+				"name": "Garukhan, Queen of the Winds"
+			}]
+		}],
+		"The Refinery": [{
+			"act": 9,
+			"level": 63,
+			"town": false,
+			"waypoint": false,
+			"bosses": [{
+				"name": "General Adus"
+			}]
+		}],
+		"The Belly of the Beast": [{
+			"act": 9,
+			"level": 63,
+			"town": false,
+			"waypoint": false,
+			"bosses": [{
+				"name": "Droolmaw"
+			}]
+		}],
+		"The Rotting Core": [{
+			"act": 9,
+			"level": 64,
+			"town": false,
+			"waypoint": false,
+			"bosses": [{
+					"name": "The Depraved Trinity"
+				},
+				{
+					"name": "Doedre, Darksoul"
+				},
+				{
+					"name": "Maligaro, The Broken"
+				},
+				{
+					"name": "Shavronne, Unbound"
+				}
+			]
+		}],
+		"Oriath Docks": [{
+			"act": 10,
+			"level": 69,
+			"town": true,
+			"waypoint": true,
+			"bosses": [
 
-        ]
-      }
-    ],
-    "The Ravaged Square":[
-      {
-        "act":10,
-        "level":64,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"The Rotten Matriarch"
-          }
-        ]
-      }
-    ],
-    "The Desecrated Chambers":[
-      {
-        "act":10,
-        "level":65,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
-          {
-            "name":"Avarius, Reassembled"
-          }
-        ]
-      }
-    ],
-    "The Canals":[
-      {
-        "act":10,
-        "level":66,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
+			]
+		}],
+		"The Ravaged Square": [{
+			"act": 10,
+			"level": 64,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+				"name": "The Rotten Matriarch"
+			}]
+		}],
+		"The Desecrated Chambers": [{
+			"act": 10,
+			"level": 65,
+			"town": false,
+			"waypoint": true,
+			"bosses": [{
+				"name": "Avarius, Reassembled"
+			}]
+		}],
+		"The Canals": [{
+			"act": 10,
+			"level": 66,
+			"town": false,
+			"waypoint": false,
+			"bosses": [
 
-        ]
-      }
-    ],
-    "The Feeding Trough":[
-      {
-        "act":10,
-        "level":67,
-        "town":false,
-        "waypoint":false,
-        "bosses":[
-          {
-            "name":"Kitava, the Insatiable"
-          }
-        ]
-      }
-    ],
-    "Oriath":[
-      {
-        "act":11,
-        "level":69,
-        "town":true,
-        "waypoint":true,
-        "bosses":[
+			]
+		}],
+		"The Feeding Trough": [{
+			"act": 10,
+			"level": 67,
+			"town": false,
+			"waypoint": false,
+			"bosses": [{
+				"name": "Kitava, the Insatiable"
+			}]
+		}],
+		"Oriath": [{
+			"act": 11,
+			"level": 69,
+			"town": true,
+			"waypoint": true,
+			"bosses": [
 
-        ]
-      }
-    ],
-    "The Templar Laboratory":[
-      {
-        "act":11,
-        "level":68,
-        "town":false,
-        "waypoint":true,
-        "bosses":[
+			]
+		}],
+		"The Templar Laboratory": [{
+			"act": 11,
+			"level": 68,
+			"town": false,
+			"waypoint": true,
+			"bosses": [
 
-        ]
-      }
-    ]
-  },
-  "vaal":{
-    "Strange Sinkhole":{
-      "bosses":[
-        [
-          "Mother of the Hive"
-        ]
-      ]
-    },
-    "Concealed Cavity":{
-      "bosses":[
-        [
-          "The All-seeing Eye"
-        ]
-      ]
-    },
-    "Sunken Shingle":{
-      "bosses":[
-        [
-          "Perquil the Lucky"
-        ]
-      ]
-    },
-    "Clouded Ridge":{
-      "bosses":[
-        [
-          "Konu, Maker of Wind"
-        ]
-      ]
-    },
-    "Forgotten Oubliette":{
-      "bosses":[
-        [
-          "Coniraya, Shadow of Malice"
-        ]
-      ]
-    },
-    "Remote Gulch":{
-      "bosses":[
-        [
-          "Sheaq, Maker of Floods"
-        ]
-      ]
-    },
-    "Narrow Ravine":{
-      "bosses":[
-        [
-          "Kamaq, Soilmaker"
-        ]
-      ]
-    },
-    "Mystical Clearing":{
-      "bosses":[
-        [
-          "Simi, the Nature Touched"
-        ]
-      ]
-    },
-    "Covered-up Hollow":{
-      "bosses":[
-        [
-          "Cintiq, the Inescapable"
-        ]
-      ]
-    },
-    "Hidden Patch":{
-      "bosses":[
-        [
-          "Thornrunner"
-        ]
-      ]
-    },
-    "Entombed Alcove":{
-      "bosses":[
-        [
-          "Shrapnelbearer"
-        ]
-      ]
-    },
-    "Secret Laboratory":{
-      "bosses":[
-        [
-          "Atziri's Pride"
-        ]
-      ]
-    },
-    "Secluded Copse":{
-      "bosses":[
-        [
-          "Kutec, Vaal Fleshsmith"
-        ]
-      ]
-    },
-    "Forbidden Chamber":{
-      "bosses":[
-        [
-          "Haviri, Vaal Metalsmith"
-        ]
-      ]
-    },
-    "Quarantined Quarters":{
-      "bosses":[
-        [
-          "The Sunburst Queen"
-        ]
-      ]
-    },
-    "Disused Furnace":{
-      "bosses":[
-        [
-          "Curator Miem"
-        ]
-      ]
-    },
-    "Blind Alley":{
-      "bosses":[
-        [
-          "M'gaska, the Living Pyre"
-        ]
-      ]
-    },
-    "Entombed Chamber":{
-      "bosses":[
-        [
-          "Ossecati, Boneshaper"
-        ]
-      ]
-    },
-    "Sacred Chambers":{
-      "bosses":[
-        [
-          "Shadow of Vengeance"
-        ]
-      ]
-    },
-    "Stagnant Canal":{
-      "bosses":[
-        [
-          "Wiraqucha, Ancient Guardian"
-        ]
-      ]
-    },
-    "Walled-off Ducts":{
-      "bosses":[
-        [
-          "Cava, Artist of Pain"
-        ]
-      ]
-    },
-    "Neglected Cellar":{
-      "bosses":[
-        [
-          "Rima, Deep Temptress"
-        ]
-      ]
-    },
-    "Arcane Chambers":{
-      "bosses":[
-        [
-          "Beheader Ataguchu"
-        ]
-      ]
-    },
-    "Inner Grounds":{
-      "bosses":[
-        [
-          "Inti of the Blood Moon"
-        ]
-      ]
-    },
-    "Sealed Corridors":{
-      "bosses":[
-        [
-          "Wiraq, the Impaler"
-        ]
-      ]
-    },
-    "Restricted Gallery":{
-      "bosses":[
-        [
-          "Ch'aska, Maker of Rain"
-        ]
-      ]
-    },
-    "Forgotten Conduit":{
-      "bosses":[
-        [
-          "Torrent of Fear"
-        ]
-      ]
-    },
-    "Ancient Catacomb":{
-      "bosses":[
-        [
-          "Commander of Flesh"
-        ]
-      ]
-    },
-    "Haunted Mineshaft":{
-      "bosses":[
-        [
-          "Calxipher"
-        ]
-      ]
-    },
-    "Abandoned Dam":{
-      "bosses":[
-        [
-          "Quetzerxi"
-        ]
-      ]
-    },
-    "Desolate Track":{
-      "bosses":[
-        [
-          "Quetzerxi"
-        ]
-      ]
-    },
-    "Reclaimed Barracks":{
-      "bosses":[
-        [
-          "Huitepa the Blind"
-        ]
-      ]
-    },
-    "Sealed Basement":{
-      "bosses":[
-        [
-          "Guraq, Daylight's Blade"
-        ]
-      ]
-    },
-    "Secluded Canal":{
-      "bosses":[
-        [
-          "Xuatl, Cutting Wind"
-        ]
-      ]
-    },
-    "Forbidden Archives":{
-      "bosses":[
-        [
-          "Exartze, the Woven Stone"
-        ]
-      ]
-    },
-    "Cremated Archives":{
-      "bosses":[
-        [
-          "Exartze, the Woven Stone"
-        ]
-      ]
-    },
-    "Twisted Inquisitorium":{
-      "bosses":[
-        [
-          "Anacuacotli, Death's Worship"
-        ]
-      ]
-    },
-    "Deathly Chambers":{
-      "bosses":[
-        [
-          "Harbinger of Disorder"
-        ]
-      ]
-    },
-    "Restricted Collection":{
-      "bosses":[
-        [
-          "Iorphia, Dream Eater"
-        ]
-      ]
-    },
-    "Side Chapel":{
-      "bosses":[
-        [
-          "Daluatti, Stoneraiser"
-        ]
-      ]
-    },
-    "Radiant Pools":{
-      "bosses":[
-        [
-          "Perquil the Lucky"
-        ]
-      ]
-    },
-    "Clouded Ledge":{
-      "bosses":[
-        [
-          "Simi, the Nature Touched"
-        ]
-      ]
-    },
-    "Sealed Repository":{
-      "bosses":[
-        [
-          "Inti of the Blood Moon"
-        ]
-      ]
-    },
-    "Flooded Complex":{
-      "bosses":[
-        [
-          "M'gaska, the Living Pyre"
-        ]
-      ]
-    },
-    "Forbidden Shrine":{
-      "bosses":[
-        [
-          "Shrapnelbearer"
-        ]
-      ]
-    },
-    "Evacuated Quarter":{
-      "bosses":[
-        [
-          "Curator Miem"
-        ]
-      ]
-    },
-    "Concealed Caldarium":{
-      "bosses":[
-        [
-          "Cava, Artist of Pain"
-        ]
-      ]
-    },
-    "Moonlit Chambers":{
-      "bosses":[
-        [
-          "Beheader Ataguchu"
-        ]
-      ]
-    },
-    "Shifting Sands":{
-      "bosses":[
-        [
-          "Wiraq, the Impaler"
-        ]
-      ]
-    },
-    "Forgotten Gulch":{
-      "bosses":[
-        [
-          "Curator Miem"
-        ]
-      ]
-    },
-    "Desolate Isle":{
-      "bosses":[
-        [
-          "Wiraqucha, Ancient Guardian"
-        ]
-      ]
-    },
-    "Dusty Bluff":{
-      "bosses":[
-        [
-          "Quetzerxi"
-        ]
-      ]
-    }
-  },
-  "labyrinth":{
-    "Aspirants' Plaza":{
-      "trial":false
-    },
-    "Trial of Piercing Truth":{
-      "trial":true
-    },
-    "Trial of Swirling Fear":{
-      "trial":true
-    },
-    "Trial of Crippling Grief":{
-      "trial":true
-    },
-    "Trial of Burning Rage":{
-      "trial":true
-    },
-    "Trial of Lingering Pain":{
-      "trial":true
-    },
-    "Trial of Stinging Doubt":{
-      "trial":true
-    }
-  }
+			]
+		}]
+	},
+	"vaal": {
+		"Strange Sinkhole": {
+			"bosses": [
+				[
+					"Mother of the Hive"
+				]
+			]
+		},
+		"Concealed Cavity": {
+			"bosses": [
+				[
+					"The All-seeing Eye"
+				]
+			]
+		},
+		"Sunken Shingle": {
+			"bosses": [
+				[
+					"Perquil the Lucky"
+				]
+			]
+		},
+		"Clouded Ridge": {
+			"bosses": [
+				[
+					"Konu, Maker of Wind"
+				]
+			]
+		},
+		"Forgotten Oubliette": {
+			"bosses": [
+				[
+					"Coniraya, Shadow of Malice"
+				]
+			]
+		},
+		"Remote Gulch": {
+			"bosses": [
+				[
+					"Sheaq, Maker of Floods"
+				]
+			]
+		},
+		"Narrow Ravine": {
+			"bosses": [
+				[
+					"Kamaq, Soilmaker"
+				]
+			]
+		},
+		"Mystical Clearing": {
+			"bosses": [
+				[
+					"Simi, the Nature Touched"
+				]
+			]
+		},
+		"Covered-up Hollow": {
+			"bosses": [
+				[
+					"Cintiq, the Inescapable"
+				]
+			]
+		},
+		"Hidden Patch": {
+			"bosses": [
+				[
+					"Thornrunner"
+				]
+			]
+		},
+		"Entombed Alcove": {
+			"bosses": [
+				[
+					"Shrapnelbearer"
+				]
+			]
+		},
+		"Secret Laboratory": {
+			"bosses": [
+				[
+					"Atziri's Pride"
+				]
+			]
+		},
+		"Secluded Copse": {
+			"bosses": [
+				[
+					"Kutec, Vaal Fleshsmith"
+				]
+			]
+		},
+		"Forbidden Chamber": {
+			"bosses": [
+				[
+					"Haviri, Vaal Metalsmith"
+				]
+			]
+		},
+		"Quarantined Quarters": {
+			"bosses": [
+				[
+					"The Sunburst Queen"
+				]
+			]
+		},
+		"Disused Furnace": {
+			"bosses": [
+				[
+					"Curator Miem"
+				]
+			]
+		},
+		"Blind Alley": {
+			"bosses": [
+				[
+					"M'gaska, the Living Pyre"
+				]
+			]
+		},
+		"Entombed Chamber": {
+			"bosses": [
+				[
+					"Ossecati, Boneshaper"
+				]
+			]
+		},
+		"Sacred Chambers": {
+			"bosses": [
+				[
+					"Shadow of Vengeance"
+				]
+			]
+		},
+		"Stagnant Canal": {
+			"bosses": [
+				[
+					"Wiraqucha, Ancient Guardian"
+				]
+			]
+		},
+		"Walled-off Ducts": {
+			"bosses": [
+				[
+					"Cava, Artist of Pain"
+				]
+			]
+		},
+		"Neglected Cellar": {
+			"bosses": [
+				[
+					"Rima, Deep Temptress"
+				]
+			]
+		},
+		"Arcane Chambers": {
+			"bosses": [
+				[
+					"Beheader Ataguchu"
+				]
+			]
+		},
+		"Inner Grounds": {
+			"bosses": [
+				[
+					"Inti of the Blood Moon"
+				]
+			]
+		},
+		"Sealed Corridors": {
+			"bosses": [
+				[
+					"Wiraq, the Impaler"
+				]
+			]
+		},
+		"Restricted Gallery": {
+			"bosses": [
+				[
+					"Ch'aska, Maker of Rain"
+				]
+			]
+		},
+		"Forgotten Conduit": {
+			"bosses": [
+				[
+					"Torrent of Fear"
+				]
+			]
+		},
+		"Ancient Catacomb": {
+			"bosses": [
+				[
+					"Commander of Flesh"
+				]
+			]
+		},
+		"Haunted Mineshaft": {
+			"bosses": [
+				[
+					"Calxipher"
+				]
+			]
+		},
+		"Abandoned Dam": {
+			"bosses": [
+				[
+					"Quetzerxi"
+				]
+			]
+		},
+		"Desolate Track": {
+			"bosses": [
+				[
+					"Quetzerxi"
+				]
+			]
+		},
+		"Reclaimed Barracks": {
+			"bosses": [
+				[
+					"Huitepa the Blind"
+				]
+			]
+		},
+		"Sealed Basement": {
+			"bosses": [
+				[
+					"Guraq, Daylight's Blade"
+				]
+			]
+		},
+		"Secluded Canal": {
+			"bosses": [
+				[
+					"Xuatl, Cutting Wind"
+				]
+			]
+		},
+		"Forbidden Archives": {
+			"bosses": [
+				[
+					"Exartze, the Woven Stone"
+				]
+			]
+		},
+		"Cremated Archives": {
+			"bosses": [
+				[
+					"Exartze, the Woven Stone"
+				]
+			]
+		},
+		"Twisted Inquisitorium": {
+			"bosses": [
+				[
+					"Anacuacotli, Death's Worship"
+				]
+			]
+		},
+		"Deathly Chambers": {
+			"bosses": [
+				[
+					"Harbinger of Disorder"
+				]
+			]
+		},
+		"Restricted Collection": {
+			"bosses": [
+				[
+					"Iorphia, Dream Eater"
+				]
+			]
+		},
+		"Side Chapel": {
+			"bosses": [
+				[
+					"Daluatti, Stoneraiser"
+				]
+			]
+		},
+		"Radiant Pools": {
+			"bosses": [
+				[
+					"Perquil the Lucky"
+				]
+			]
+		},
+		"Clouded Ledge": {
+			"bosses": [
+				[
+					"Simi, the Nature Touched"
+				]
+			]
+		},
+		"Sealed Repository": {
+			"bosses": [
+				[
+					"Inti of the Blood Moon"
+				]
+			]
+		},
+		"Flooded Complex": {
+			"bosses": [
+				[
+					"M'gaska, the Living Pyre"
+				]
+			]
+		},
+		"Forbidden Shrine": {
+			"bosses": [
+				[
+					"Shrapnelbearer"
+				]
+			]
+		},
+		"Evacuated Quarter": {
+			"bosses": [
+				[
+					"Curator Miem"
+				]
+			]
+		},
+		"Concealed Caldarium": {
+			"bosses": [
+				[
+					"Cava, Artist of Pain"
+				]
+			]
+		},
+		"Moonlit Chambers": {
+			"bosses": [
+				[
+					"Beheader Ataguchu"
+				]
+			]
+		},
+		"Shifting Sands": {
+			"bosses": [
+				[
+					"Wiraq, the Impaler"
+				]
+			]
+		},
+		"Forgotten Gulch": {
+			"bosses": [
+				[
+					"Curator Miem"
+				]
+			]
+		},
+		"Desolate Isle": {
+			"bosses": [
+				[
+					"Wiraqucha, Ancient Guardian"
+				]
+			]
+		},
+		"Dusty Bluff": {
+			"bosses": [
+				[
+					"Quetzerxi"
+				]
+			]
+		}
+	},
+	"labyrinth": {
+		"Aspirants' Plaza": {
+			"trial": false
+		},
+		"Trial of Piercing Truth": {
+			"trial": true
+		},
+		"Trial of Swirling Fear": {
+			"trial": true
+		},
+		"Trial of Crippling Grief": {
+			"trial": true
+		},
+		"Trial of Burning Rage": {
+			"trial": true
+		},
+		"Trial of Lingering Pain": {
+			"trial": true
+		},
+		"Trial of Stinging Doubt": {
+			"trial": true
+		}
+	}
 }

--- a/resource/areas.json
+++ b/resource/areas.json
@@ -2402,7 +2402,7 @@
     ]
   },
   "map": {
-    "Beach Map": [
+    "Beach": [
       {
         "level": 68,
         "tier": 1,
@@ -2413,7 +2413,7 @@
         ]
       }
     ],
-    "Dungeon Map": [
+    "Dungeon": [
       {
         "level": 68,
         "tier": 1,
@@ -2424,7 +2424,7 @@
         ]
       }
     ],
-    "Graveyard Map": [
+    "Graveyard": [
       {
         "level": 68,
         "tier": 1,
@@ -2441,7 +2441,7 @@
         ]
       }
     ],
-    "Lookout Map": [
+    "Lookout": [
       {
         "level": 68,
         "tier": 1,
@@ -2452,7 +2452,7 @@
         ]
       }
     ],
-    "Alleyways Map": [
+    "Alleyways": [
       {
         "level": 69,
         "tier": 2,
@@ -2463,7 +2463,7 @@
         ]
       }
     ],
-    "Arid Lake Map": [
+    "Arid Lake": [
       {
         "level": 69,
         "tier": 2,
@@ -2474,7 +2474,7 @@
         ]
       }
     ],
-    "Desert Map": [
+    "Desert": [
       {
         "level": 69,
         "tier": 2,
@@ -2485,7 +2485,7 @@
         ]
       }
     ],
-    "Flooded Mine Map": [
+    "Flooded Mine": [
       {
         "level": 69,
         "tier": 2,
@@ -2496,7 +2496,7 @@
         ]
       }
     ],
-    "Marshes Map": [
+    "Marshes": [
       {
         "level": 69,
         "tier": 2,
@@ -2507,7 +2507,7 @@
         ]
       }
     ],
-    "Pen Map": [
+    "Pen": [
       {
         "level": 69,
         "tier": 2,
@@ -2518,7 +2518,7 @@
         ]
       }
     ],
-    "Arcade Map": [
+    "Arcade": [
       {
         "level": 70,
         "tier": 3,
@@ -2532,7 +2532,7 @@
         ]
       }
     ],
-    "Burial Chambers Map": [
+    "Burial Chambers": [
       {
         "level": 70,
         "tier": 3,
@@ -2543,7 +2543,7 @@
         ]
       }
     ],
-    "Cage Map": [
+    "Cage": [
       {
         "level": 70,
         "tier": 3,
@@ -2554,7 +2554,7 @@
         ]
       }
     ],
-    "Cells Map": [
+    "Cells": [
       {
         "level": 70,
         "tier": 3,
@@ -2565,7 +2565,7 @@
         ]
       }
     ],
-    "Excavation Map": [
+    "Excavation": [
       {
         "level": 70,
         "tier": 3,
@@ -2579,7 +2579,7 @@
         ]
       }
     ],
-    "Iceberg Map": [
+    "Iceberg": [
       {
         "level": 70,
         "tier": 3,
@@ -2590,7 +2590,7 @@
         ]
       }
     ],
-    "Leyline Map": [
+    "Leyline": [
       {
         "level": 70,
         "tier": 3,
@@ -2601,7 +2601,7 @@
         ]
       }
     ],
-    "Peninsula Map": [
+    "Peninsula": [
       {
         "level": 70,
         "tier": 3,
@@ -2612,7 +2612,7 @@
         ]
       }
     ],
-    "Port Map": [
+    "Port": [
       {
         "level": 70,
         "tier": 3,
@@ -2623,7 +2623,7 @@
         ]
       }
     ],
-    "Springs Map": [
+    "Springs": [
       {
         "level": 70,
         "tier": 3,
@@ -2687,7 +2687,7 @@
         ]
       }
     ],
-    "Canyon Map": [
+    "Canyon": [
       {
         "level": 71,
         "tier": 4,
@@ -2701,7 +2701,7 @@
         ]
       }
     ],
-    "Chateau Map": [
+    "Chateau": [
       {
         "level": 71,
         "tier": 4,
@@ -2712,7 +2712,7 @@
         ]
       }
     ],
-    "City Square Map": [
+    "City Square": [
       {
         "level": 71,
         "tier": 4,
@@ -2729,7 +2729,7 @@
         ]
       }
     ],
-    "Courthouse Map": [
+    "Courthouse": [
       {
         "level": 71,
         "tier": 4,
@@ -2746,7 +2746,7 @@
         ]
       }
     ],
-    "Gorge Map": [
+    "Gorge": [
       {
         "level": 71,
         "tier": 4,
@@ -2757,7 +2757,7 @@
         ]
       }
     ],
-    "Grotto Map": [
+    "Grotto": [
       {
         "level": 71,
         "tier": 4,
@@ -2768,7 +2768,7 @@
         ]
       }
     ],
-    "Lighthouse Map": [
+    "Lighthouse": [
       {
         "level": 71,
         "tier": 4,
@@ -2779,7 +2779,7 @@
         ]
       }
     ],
-    "Relic Chambers Map": [
+    "Relic Chambers": [
       {
         "level": 71,
         "tier": 4,
@@ -2790,7 +2790,7 @@
         ]
       }
     ],
-    "Strand Map": [
+    "Strand": [
       {
         "level": 71,
         "tier": 4,
@@ -2812,7 +2812,7 @@
         ]
       }
     ],
-    "Volcano Map": [
+    "Volcano": [
       {
         "level": 71,
         "tier": 4,
@@ -2823,7 +2823,7 @@
         ]
       }
     ],
-    "Ancient City Map": [
+    "Ancient City": [
       {
         "level": 72,
         "tier": 5,
@@ -2834,7 +2834,7 @@
         ]
       }
     ],
-    "Barrows Map": [
+    "Barrows": [
       {
         "level": 72,
         "tier": 5,
@@ -2845,7 +2845,7 @@
         ]
       }
     ],
-    "Channel Map": [
+    "Channel": [
       {
         "level": 72,
         "tier": 5,
@@ -2856,7 +2856,7 @@
         ]
       }
     ],
-    "Conservatory Map": [
+    "Conservatory": [
       {
         "level": 72,
         "tier": 5,
@@ -2867,7 +2867,7 @@
         ]
       }
     ],
-    "Haunted Mansion Map": [
+    "Haunted Mansion": [
       {
         "level": 72,
         "tier": 5,
@@ -2881,7 +2881,7 @@
         ]
       }
     ],
-    "Ivory Temple Map": [
+    "Ivory Temple": [
       {
         "level": 72,
         "tier": 5,
@@ -2892,7 +2892,7 @@
         ]
       }
     ],
-    "Maze Map": [
+    "Maze": [
       {
         "level": 72,
         "tier": 5,
@@ -2903,7 +2903,7 @@
         ]
       }
     ],
-    "Spider Lair Map": [
+    "Spider Lair": [
       {
         "level": 72,
         "tier": 5,
@@ -2914,7 +2914,7 @@
         ]
       }
     ],
-    "Sulphur Vents Map": [
+    "Sulphur Vents": [
       {
         "level": 72,
         "tier": 5,
@@ -2925,7 +2925,7 @@
         ]
       }
     ],
-    "Toxic Sewer Map": [
+    "Toxic Sewer": [
       {
         "level": 72,
         "tier": 5,
@@ -2943,7 +2943,7 @@
         "bosses": []
       }
     ],
-    "Academy Map": [
+    "Academy": [
       {
         "level": 73,
         "tier": 6,
@@ -2954,7 +2954,7 @@
         ]
       }
     ],
-    "Atoll Map": [
+    "Atoll": [
       {
         "level": 73,
         "tier": 6,
@@ -2979,7 +2979,7 @@
         ]
       }
     ],
-    "Ashen Wood Map": [
+    "Ashen Wood": [
       {
         "level": 73,
         "tier": 6,
@@ -2990,7 +2990,7 @@
         ]
       }
     ],
-    "Cemetery Map": [
+    "Cemetery": [
       {
         "level": 73,
         "tier": 6,
@@ -3012,7 +3012,7 @@
         ]
       }
     ],
-    "Fields Map": [
+    "Fields": [
       {
         "level": 73,
         "tier": 6,
@@ -3023,7 +3023,7 @@
         ]
       }
     ],
-    "Jungle Valley Map": [
+    "Jungle Valley": [
       {
         "level": 73,
         "tier": 6,
@@ -3034,7 +3034,7 @@
         ]
       }
     ],
-    "Mausoleum Map": [
+    "Mausoleum": [
       {
         "level": 73,
         "tier": 6,
@@ -3045,7 +3045,7 @@
         ]
       }
     ],
-    "Phantasmagoria Map": [
+    "Phantasmagoria": [
       {
         "level": 73,
         "tier": 6,
@@ -3056,7 +3056,7 @@
         ]
       }
     ],
-    "Thicket Map": [
+    "Thicket": [
       {
         "level": 73,
         "tier": 6,
@@ -3067,7 +3067,7 @@
         ]
       }
     ],
-    "Underground Sea Map": [
+    "Underground Sea": [
       {
         "level": 73,
         "tier": 6,
@@ -3078,7 +3078,7 @@
         ]
       }
     ],
-    "Wharf Map": [
+    "Wharf": [
       {
         "level": 73,
         "tier": 6,
@@ -3089,7 +3089,7 @@
         ]
       }
     ],
-    "Arachnid Nest Map": [
+    "Arachnid Nest": [
       {
         "level": 74,
         "tier": 7,
@@ -3100,7 +3100,7 @@
         ]
       }
     ],
-    "Bazaar Map": [
+    "Bazaar": [
       {
         "level": 74,
         "tier": 7,
@@ -3111,7 +3111,7 @@
         ]
       }
     ],
-    "Bone Crypt Map": [
+    "Bone Crypt": [
       {
         "level": 74,
         "tier": 7,
@@ -3133,7 +3133,7 @@
         ]
       }
     ],
-    "Coral Ruins Map": [
+    "Coral Ruins": [
       {
         "level": 74,
         "tier": 7,
@@ -3144,7 +3144,7 @@
         ]
       }
     ],
-    "Dunes Map": [
+    "Dunes": [
       {
         "level": 74,
         "tier": 7,
@@ -3166,7 +3166,7 @@
         ]
       }
     ],
-    "Gardens Map": [
+    "Gardens": [
       {
         "level": 74,
         "tier": 7,
@@ -3177,7 +3177,7 @@
         ]
       }
     ],
-    "Lava Chamber Map": [
+    "Lava Chamber": [
       {
         "level": 74,
         "tier": 7,
@@ -3188,7 +3188,7 @@
         ]
       }
     ],
-    "Ramparts Map": [
+    "Ramparts": [
       {
         "level": 74,
         "tier": 7,
@@ -3199,7 +3199,7 @@
         ]
       }
     ],
-    "Residence Map": [
+    "Residence": [
       {
         "level": 74,
         "tier": 7,
@@ -3210,7 +3210,7 @@
         ]
       }
     ],
-    "Tribunal Map": [
+    "Tribunal": [
       {
         "level": 74,
         "tier": 7,
@@ -3221,7 +3221,7 @@
         ]
       }
     ],
-    "Underground River Map": [
+    "Underground River": [
       {
         "level": 74,
         "tier": 7,
@@ -3249,7 +3249,7 @@
         ]
       }
     ],
-    "Armoury Map": [
+    "Armoury": [
       {
         "level": 75,
         "tier": 8,
@@ -3260,7 +3260,7 @@
         ]
       }
     ],
-    "Courtyard Map": [
+    "Courtyard": [
       {
         "level": 75,
         "tier": 8,
@@ -3288,7 +3288,7 @@
         ]
       }
     ],
-    "Geode Map": [
+    "Geode": [
       {
         "level": 75,
         "tier": 8,
@@ -3299,7 +3299,7 @@
         ]
       }
     ],
-    "Infested Valley Map": [
+    "Infested Valley": [
       {
         "level": 75,
         "tier": 8,
@@ -3310,7 +3310,7 @@
         ]
       }
     ],
-    "Laboratory Map": [
+    "Laboratory": [
       {
         "level": 75,
         "tier": 8,
@@ -3321,7 +3321,7 @@
         ]
       }
     ],
-    "Mineral Pools Map": [
+    "Mineral Pools": [
       {
         "level": 75,
         "tier": 8,
@@ -3335,7 +3335,7 @@
         ]
       }
     ],
-    "Mud Geyser Map": [
+    "Mud Geyser": [
       {
         "level": 75,
         "tier": 8,
@@ -3346,7 +3346,7 @@
         ]
       }
     ],
-    "Overgrown Ruin Map": [
+    "Overgrown Ruin": [
       {
         "level": 75,
         "tier": 8,
@@ -3357,7 +3357,7 @@
         ]
       }
     ],
-    "Shore Map": [
+    "Shore": [
       {
         "level": 75,
         "tier": 8,
@@ -3397,7 +3397,7 @@
         ]
       }
     ],
-    "Tropical Island Map": [
+    "Tropical Island": [
       {
         "level": 75,
         "tier": 8,
@@ -3439,7 +3439,7 @@
         ]
       }
     ],
-    "Vaal Pyramid Map": [
+    "Vaal Pyramid": [
       {
         "level": 75,
         "tier": 8,
@@ -3467,7 +3467,7 @@
         ]
       }
     ],
-    "Arena Map": [
+    "Arena": [
       {
         "level": 76,
         "tier": 9,
@@ -3484,7 +3484,7 @@
         ]
       }
     ],
-    "Estuary Map": [
+    "Estuary": [
       {
         "level": 76,
         "tier": 9,
@@ -3495,7 +3495,7 @@
         ]
       }
     ],
-    "Moon Temple Map": [
+    "Moon Temple": [
       {
         "level": 76,
         "tier": 9,
@@ -3520,7 +3520,7 @@
         ]
       }
     ],
-    "Museum Map": [
+    "Museum": [
       {
         "level": 76,
         "tier": 9,
@@ -3542,7 +3542,7 @@
         ]
       }
     ],
-    "Plateau Map": [
+    "Plateau": [
       {
         "level": 76,
         "tier": 9,
@@ -3556,7 +3556,7 @@
         ]
       }
     ],
-    "Scriptorium Map": [
+    "Scriptorium": [
       {
         "level": 76,
         "tier": 9,
@@ -3567,7 +3567,7 @@
         ]
       }
     ],
-    "Sepulchre Map": [
+    "Sepulchre": [
       {
         "level": 76,
         "tier": 9,
@@ -3578,7 +3578,7 @@
         ]
       }
     ],
-    "Temple Map": [
+    "Temple": [
       {
         "level": 76,
         "tier": 9,
@@ -3600,7 +3600,7 @@
         ]
       }
     ],
-    "Tower Map": [
+    "Tower": [
       {
         "level": 76,
         "tier": 9,
@@ -3611,7 +3611,7 @@
         ]
       }
     ],
-    "Vault Map": [
+    "Vault": [
       {
         "level": 76,
         "tier": 9,
@@ -3622,7 +3622,7 @@
         ]
       }
     ],
-    "Waste Pool Map": [
+    "Waste Pool": [
       {
         "level": 76,
         "tier": 9,
@@ -3633,7 +3633,7 @@
         ]
       }
     ],
-    "Arachnid Tomb Map": [
+    "Arachnid Tomb": [
       {
         "level": 77,
         "tier": 10,
@@ -3644,7 +3644,7 @@
         ]
       }
     ],
-    "Belfry Map": [
+    "Belfry": [
       {
         "level": 77,
         "tier": 10,
@@ -3655,7 +3655,7 @@
         ]
       }
     ],
-    "Bog Map": [
+    "Bog": [
       {
         "level": 77,
         "tier": 10,
@@ -3666,7 +3666,7 @@
         ]
       }
     ],
-    "Cursed Crypt Map": [
+    "Cursed Crypt": [
       {
         "level": 77,
         "tier": 10,
@@ -3688,7 +3688,7 @@
         ]
       }
     ],
-    "Orchard Map": [
+    "Orchard": [
       {
         "level": 77,
         "tier": 10,
@@ -3699,7 +3699,7 @@
         ]
       }
     ],
-    "Pier Map": [
+    "Pier": [
       {
         "level": 77,
         "tier": 10,
@@ -3710,7 +3710,7 @@
         ]
       }
     ],
-    "Precinct Map": [
+    "Precinct": [
       {
         "level": 77,
         "tier": 10,
@@ -3721,7 +3721,7 @@
         ]
       }
     ],
-    "Shipyard Map": [
+    "Shipyard": [
       {
         "level": 77,
         "tier": 10,
@@ -3732,7 +3732,7 @@
         ]
       }
     ],
-    "Siege Map": [
+    "Siege": [
       {
         "level": 77,
         "tier": 10,
@@ -3754,7 +3754,7 @@
         ]
       }
     ],
-    "Wasteland Map": [
+    "Wasteland": [
       {
         "level": 77,
         "tier": 10,
@@ -3765,7 +3765,7 @@
         ]
       }
     ],
-    "Colonnade Map": [
+    "Colonnade": [
       {
         "level": 78,
         "tier": 11,
@@ -3776,7 +3776,7 @@
         ]
       }
     ],
-    "Coves Map": [
+    "Coves": [
       {
         "level": 78,
         "tier": 11,
@@ -3787,7 +3787,7 @@
         ]
       }
     ],
-    "Factory Map": [
+    "Factory": [
       {
         "level": 78,
         "tier": 11,
@@ -3798,7 +3798,7 @@
         ]
       }
     ],
-    "Mesa Map": [
+    "Mesa": [
       {
         "level": 78,
         "tier": 11,
@@ -3809,7 +3809,7 @@
         ]
       }
     ],
-    "Lair Map": [
+    "Lair": [
       {
         "level": 78,
         "tier": 11,
@@ -3820,7 +3820,7 @@
         ]
       }
     ],
-    "Pit Map": [
+    "Pit": [
       {
         "level": 78,
         "tier": 11,
@@ -3831,7 +3831,7 @@
         ]
       }
     ],
-    "Primordial Pool Map": [
+    "Primordial Pool": [
       {
         "level": 78,
         "tier": 11,
@@ -3842,7 +3842,7 @@
         ]
       }
     ],
-    "Promenade Map": [
+    "Promenade": [
       {
         "level": 78,
         "tier": 11,
@@ -3864,7 +3864,7 @@
         ]
       }
     ],
-    "Spider Forest Map": [
+    "Spider Forest": [
       {
         "level": 78,
         "tier": 11,
@@ -3875,7 +3875,7 @@
         ]
       }
     ],
-    "Waterways Map": [
+    "Waterways": [
       {
         "level": 78,
         "tier": 11,
@@ -3886,7 +3886,7 @@
         ]
       }
     ],
-    "Castle Ruins Map": [
+    "Castle Ruins": [
       {
         "level": 79,
         "tier": 12,
@@ -3897,7 +3897,7 @@
         ]
       }
     ],
-    "Crystal Ore Map": [
+    "Crystal Ore": [
       {
         "level": 79,
         "tier": 12,
@@ -3908,7 +3908,7 @@
         ]
       }
     ],
-    "Defiled Cathedral Map": [
+    "Defiled Cathedral": [
       {
         "level": 79,
         "tier": 12,
@@ -3919,7 +3919,7 @@
         ]
       }
     ],
-    "Necropolis Map": [
+    "Necropolis": [
       {
         "level": 79,
         "tier": 12,
@@ -3941,7 +3941,7 @@
         ]
       }
     ],
-    "Overgrown Shrine Map": [
+    "Overgrown Shrine": [
       {
         "level": 79,
         "tier": 12,
@@ -3963,7 +3963,7 @@
         ]
       }
     ],
-    "Racecourse Map": [
+    "Racecourse": [
       {
         "level": 79,
         "tier": 12,
@@ -3974,7 +3974,7 @@
         ]
       }
     ],
-    "Summit Map": [
+    "Summit": [
       {
         "level": 79,
         "tier": 12,
@@ -3985,7 +3985,7 @@
         ]
       }
     ],
-    "Torture Chamber Map": [
+    "Torture Chamber": [
       {
         "level": 79,
         "tier": 12,
@@ -4003,7 +4003,7 @@
         "bosses": []
       }
     ],
-    "Villa Map": [
+    "Villa": [
       {
         "level": 79,
         "tier": 12,
@@ -4014,7 +4014,7 @@
         ]
       }
     ],
-    "Arsenal Map": [
+    "Arsenal": [
       {
         "level": 80,
         "tier": 13,
@@ -4025,7 +4025,7 @@
         ]
       }
     ],
-    "Caldera Map": [
+    "Caldera": [
       {
         "level": 80,
         "tier": 13,
@@ -4036,7 +4036,7 @@
         ]
       }
     ],
-    "Core Map": [
+    "Core": [
       {
         "level": 80,
         "tier": 13,
@@ -4058,7 +4058,7 @@
         ]
       }
     ],
-    "Desert Spring Map": [
+    "Desert Spring": [
       {
         "level": 80,
         "tier": 13,
@@ -4069,7 +4069,7 @@
         ]
       }
     ],
-    "Ghetto Map": [
+    "Ghetto": [
       {
         "level": 80,
         "tier": 13,
@@ -4080,7 +4080,7 @@
         ]
       }
     ],
-    "Malformation Map": [
+    "Malformation": [
       {
         "level": 80,
         "tier": 13,
@@ -4091,7 +4091,7 @@
         ]
       }
     ],
-    "Park Map": [
+    "Park": [
       {
         "level": 80,
         "tier": 13,
@@ -4102,7 +4102,7 @@
         ]
       }
     ],
-    "Shrine Map": [
+    "Shrine": [
       {
         "level": 80,
         "tier": 13,
@@ -4113,7 +4113,7 @@
         ]
       }
     ],
-    "Terrace Map": [
+    "Terrace": [
       {
         "level": 80,
         "tier": 13,
@@ -4144,7 +4144,7 @@
         ]
       }
     ],
-    "Acid Lakes Map": [
+    "Acid Lakes": [
       {
         "level": 81,
         "tier": 14,
@@ -4155,7 +4155,7 @@
         ]
       }
     ],
-    "Colosseum Map": [
+    "Colosseum": [
       {
         "level": 81,
         "tier": 14,
@@ -4166,7 +4166,7 @@
         ]
       }
     ],
-    "Crimson Temple Map": [
+    "Crimson Temple": [
       {
         "level": 81,
         "tier": 14,
@@ -4177,7 +4177,7 @@
         ]
       }
     ],
-    "Dark Forest Map": [
+    "Dark Forest": [
       {
         "level": 81,
         "tier": 14,
@@ -4188,7 +4188,7 @@
         ]
       }
     ],
-    "Dig Map": [
+    "Dig": [
       {
         "level": 81,
         "tier": 14,
@@ -4199,7 +4199,7 @@
         ]
       }
     ],
-    "Palace Map": [
+    "Palace": [
       {
         "level": 81,
         "tier": 14,
@@ -4210,7 +4210,7 @@
         ]
       }
     ],
-    "Plaza Map": [
+    "Plaza": [
       {
         "level": 81,
         "tier": 14,
@@ -4221,7 +4221,7 @@
         ]
       }
     ],
-    "Basilica Map": [
+    "Basilica": [
       {
         "level": 82,
         "tier": 15,
@@ -4235,7 +4235,7 @@
         ]
       }
     ],
-    "Carcass Map": [
+    "Carcass": [
       {
         "level": 82,
         "tier": 15,
@@ -4246,7 +4246,7 @@
         ]
       }
     ],
-    "Lava Lake Map": [
+    "Lava Lake": [
       {
         "level": 82,
         "tier": 15,
@@ -4257,7 +4257,7 @@
         ]
       }
     ],
-    "Reef Map": [
+    "Reef": [
       {
         "level": 82,
         "tier": 15,
@@ -4268,7 +4268,7 @@
         ]
       }
     ],
-    "Sunken City Map": [
+    "Sunken City": [
       {
         "level": 82,
         "tier": 15,
@@ -4290,7 +4290,7 @@
         ]
       }
     ],
-    "Forge of the Phoenix Map": [
+    "Forge of the Phoenix": [
       {
         "level": 83,
         "tier": 16,
@@ -4301,7 +4301,7 @@
         ]
       }
     ],
-    "Lair of the Hydra Map": [
+    "Lair of the Hydra": [
       {
         "level": 83,
         "tier": 16,
@@ -4312,7 +4312,7 @@
         ]
       }
     ],
-    "Maze of the Minotaur Map": [
+    "Maze of the Minotaur": [
       {
         "level": 83,
         "tier": 16,
@@ -4323,7 +4323,7 @@
         ]
       }
     ],
-    "Pit of the Chimera Map": [
+    "Pit of the Chimera": [
       {
         "level": 83,
         "tier": 16,
@@ -4334,7 +4334,7 @@
         ]
       }
     ],
-    "Vaal Temple Map": [
+    "Vaal Temple": [
       {
         "level": 83,
         "tier": 16,

--- a/resource/areas.json
+++ b/resource/areas.json
@@ -1,2067 +1,2390 @@
 {
-	"area": {
-		"Unearthed Hideout": [{
-			"act": 1,
-			"level": 20,
-			"town": false,
-			"waypoint": true,
-			"bosses": [
-
-			]
-		}],
-		"Enlightened Hideout": [{
-			"act": 1,
-			"level": 20,
-			"town": false,
-			"waypoint": true,
-			"bosses": [
-
-			]
-		}],
-		"Coastal Hideout": [{
-			"act": 1,
-			"level": 20,
-			"town": false,
-			"waypoint": true,
-			"bosses": [
-
-			]
-		}],
-		"Overgrown Hideout": [{
-			"act": 1,
-			"level": 20,
-			"town": false,
-			"waypoint": true,
-			"bosses": [
-
-			]
-		}],
-		"Lush Hideout": [{
-			"act": 1,
-			"level": 20,
-			"town": false,
-			"waypoint": true,
-			"bosses": [
-
-			]
-		}],
-		"Battle-scarred Hideout": [{
-			"act": 1,
-			"level": 20,
-			"town": false,
-			"waypoint": true,
-			"bosses": [
-
-			]
-		}],
-		"Backstreet Hideout": [{
-			"act": 1,
-			"level": 20,
-			"town": false,
-			"waypoint": true,
-			"bosses": [
-
-			]
-		}],
-		"Immaculate Hideout": [{
-			"act": 1,
-			"level": 20,
-			"town": false,
-			"waypoint": true,
-			"bosses": [
-
-			]
-		}],
-		"Lioneye's Watch": [{
-				"act": 1,
-				"level": 13,
-				"town": true,
-				"waypoint": true,
-				"bosses": [
-
-				]
-			},
-			{
-				"act": 6,
-				"level": 50,
-				"town": true,
-				"waypoint": true,
-				"bosses": [
-
-				]
-			}
-		],
-		"The Twilight Strand": [{
-				"act": 1,
-				"level": 1,
-				"town": false,
-				"waypoint": false,
-				"bosses": [{
-					"name": "Hillock"
-				}]
-			},
-			{
-				"act": 6,
-				"level": 45,
-				"town": false,
-				"waypoint": false,
-				"bosses": [{
-					"name": "Rhys of Abram"
-				}]
-			}
-		],
-		"The Coast": [{
-				"act": 1,
-				"level": 2,
-				"town": false,
-				"waypoint": true,
-				"bosses": [{
-					"name": "Fire Fury"
-				}]
-			},
-			{
-				"act": 6,
-				"level": 45,
-				"town": false,
-				"waypoint": true,
-				"bosses": [
-
-				]
-			}
-		],
-		"The Tidal Island": [{
-				"act": 1,
-				"level": 3,
-				"town": false,
-				"waypoint": false,
-				"bosses": [{
-					"name": "Hailrake"
-				}]
-			},
-			{
-				"act": 6,
-				"level": 45,
-				"town": false,
-				"waypoint": false,
-				"bosses": [{
-					"name": "Riptide"
-				}]
-			}
-		],
-		"The Mud Flats": [{
-				"act": 1,
-				"level": 4,
-				"town": false,
-				"waypoint": false,
-				"bosses": [{
-					"name": "Oozeback Bloom"
-				}]
-			},
-			{
-				"act": 6,
-				"level": 46,
-				"town": false,
-				"waypoint": false,
-				"bosses": [{
-						"name": "The Dishonoured Queen"
-					},
-					{
-						"name": "Forgotten Warrior"
-					}
-				]
-			}
-		],
-		"The Fetid Pool": [{
-			"act": 1,
-			"level": 5,
-			"town": false,
-			"waypoint": false,
-			"bosses": [{
-				"name": "Kadavrus the Defiler"
-			}]
-		}],
-		"The Flooded Depths": [{
-			"act": 1,
-			"level": 6,
-			"town": false,
-			"waypoint": false,
-			"bosses": [{
-				"name": "The Deep Dweller"
-			}]
-		}],
-		"The Submerged Passage": [{
-			"act": 1,
-			"level": 5,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-				"name": "Brood Princess"
-			}]
-		}],
-		"The Ledge": [{
-			"act": 1,
-			"level": 6,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-				"name": "Kuduku, the False God"
-			}]
-		}],
-		"The Climb": [{
-			"act": 1,
-			"level": 7,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-					"name": "Ironpoint the Forsaken"
-				},
-				{
-					"name": "The Faun"
-				}
-			]
-		}],
-		"The Lower Prison": [{
-				"act": 1,
-				"level": 8,
-				"town": false,
-				"waypoint": true,
-				"bosses": [{
-					"name": "Chatters"
-				}]
-			},
-			{
-				"act": 6,
-				"level": 47,
-				"town": false,
-				"waypoint": true,
-				"bosses": [
-
-				]
-			}
-		],
-		"The Upper Prison": [{
-			"act": 1,
-			"level": 9,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-					"name": "Sawbones"
-				},
-				{
-					"name": "Brutus, Lord Incarcerator"
-				}
-			]
-		}],
-		"Prisoner's Gate": [{
-				"act": 1,
-				"level": 10,
-				"town": false,
-				"waypoint": true,
-				"bosses": [{
-						"name": "Ungulath"
-					},
-					{
-						"name": "The Burning Menace"
-					}
-				]
-			},
-			{
-				"act": 6,
-				"level": 47,
-				"town": false,
-				"waypoint": true,
-				"bosses": [{
-					"name": "Abberath, the Cloven One"
-				}]
-			}
-		],
-		"The Ship Graveyard": [{
-			"act": 1,
-			"level": 11,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-				"name": "Captain Fairgraves"
-			}]
-		}],
-		"The Ship Graveyard Cave": [{
-			"act": 1,
-			"level": 12,
-			"town": false,
-			"waypoint": false,
-			"bosses": [{
-				"name": "Stranglecharm"
-			}]
-		}],
-		"The Cavern of Wrath": [{
-			"act": 1,
-			"level": 12,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-				"name": "Amarissa, Daughter of Merveil"
-			}]
-		}],
-		"The Cavern of Anger": [{
-				"act": 1,
-				"level": 13,
-				"town": false,
-				"waypoint": false,
-				"bosses": [{
-						"name": "Ambrosia, Daughter of Merveil"
-					},
-					{
-						"name": "Merveil, the Siren"
-					}
-				]
-			},
-			{
-				"act": 6,
-				"level": 49,
-				"town": false,
-				"waypoint": false,
-				"bosses": [{
-					"name": "Brinecrack"
-				}]
-			}
-		],
-		"The Forest Encampment": [{
-			"act": 2,
-			"level": 23,
-			"town": true,
-			"waypoint": true,
-			"bosses": [
-
-			]
-		}],
-		"The Southern Forest": [{
-				"act": 2,
-				"level": 13,
-				"town": false,
-				"waypoint": true,
-				"bosses": [
-
-				]
-			},
-			{
-				"act": 6,
-				"level": 49,
-				"town": false,
-				"waypoint": true,
-				"bosses": [{
-					"name": "Hollowskull, the Willing Host"
-				}]
-			}
-		],
-		"The Old Fields": [{
-			"act": 2,
-			"level": 14,
-			"town": false,
-			"waypoint": false,
-			"bosses": [{
-				"name": "Gneiss"
-			}]
-		}],
-		"The Den": [{
-				"act": 2,
-				"level": 15,
-				"town": false,
-				"waypoint": false,
-				"bosses": [{
-					"name": "The Great White Beast"
-				}]
-			},
-			{
-				"act": 7,
-				"level": 53,
-				"town": false,
-				"waypoint": true,
-				"bosses": [{
-						"name": "The Great White Bones"
-					},
-					{
-						"name": "The Bone Sculptor"
-					}
-				]
-			}
-		],
-		"The Crossroads": [{
-				"act": 2,
-				"level": 15,
-				"town": false,
-				"waypoint": true,
-				"bosses": [{
-					"name": "Bravalo"
-				}]
-			},
-			{
-				"act": 7,
-				"level": 51,
-				"town": false,
-				"waypoint": true,
-				"bosses": [
-
-				]
-			}
-		],
-		"The Crypt Level 1": [{
-			"act": 2,
-			"level": 17,
-			"town": false,
-			"waypoint": true,
-			"bosses": [
-
-			]
-		}],
-		"The Crypt Level 2": [{
-			"act": 2,
-			"level": 18,
-			"town": false,
-			"waypoint": false,
-			"bosses": [{
-				"name": "Archbishop Geofri the Abashed"
-			}]
-		}],
-		"The Chamber of Sins Level 1": [{
-				"act": 2,
-				"level": 15,
-				"town": false,
-				"waypoint": true,
-				"bosses": [{
-					"name": "Black Death"
-				}]
-			},
-			{
-				"act": 7,
-				"level": 52,
-				"town": false,
-				"waypoint": true,
-				"bosses": [
-
-				]
-			}
-		],
-		"The Chamber of Sins Level 2": [{
-				"act": 2,
-				"level": 16,
-				"town": false,
-				"waypoint": false,
-				"bosses": [{
-					"name": "Fidelitas, the Mourning"
-				}]
-			},
-			{
-				"act": 7,
-				"level": 52,
-				"town": false,
-				"waypoint": false,
-				"bosses": [{
-					"name": "Plague Retch"
-				}]
-			}
-		],
-		"The Broken Bridge": [{
-				"act": 2,
-				"level": 16,
-				"town": false,
-				"waypoint": true,
-				"bosses": [{
-					"name": "Kraityn, Scarbearer"
-				}]
-			},
-			{
-				"act": 7,
-				"level": 50,
-				"town": false,
-				"waypoint": false,
-				"bosses": [
-
-				]
-			}
-		],
-		"The Riverways": [{
-				"act": 2,
-				"level": 15,
-				"town": false,
-				"waypoint": true,
-				"bosses": [{
-					"name": "Targa, Beast Poacher"
-				}]
-			},
-			{
-				"act": 6,
-				"level": 48,
-				"town": false,
-				"waypoint": true,
-				"bosses": [{
-					"name": "The Animal Pack"
-				}]
-			}
-		],
-		"The Northern Forest": [{
-				"act": 2,
-				"level": 21,
-				"town": false,
-				"waypoint": true,
-				"bosses": [{
-					"name": "Seleslatha"
-				}]
-			},
-			{
-				"act": 7,
-				"level": 53,
-				"town": false,
-				"waypoint": true,
-				"bosses": [{
-					"name": "Tunnelworm"
-				}]
-			}
-		],
-		"The Western Forest": [{
-				"act": 2,
-				"level": 17,
-				"town": false,
-				"waypoint": true,
-				"bosses": [{
-						"name": "Alira Darktongue"
-					},
-					{
-						"name": "Captain Arteri"
-					}
-				]
-			},
-			{
-				"act": 6,
-				"level": 48,
-				"town": false,
-				"waypoint": true,
-				"bosses": [{
-					"name": "Defiled Proclamation"
-				}]
-			}
-		],
-		"The Weaver's Chambers": [{
-			"act": 2,
-			"level": 18,
-			"town": false,
-			"waypoint": false,
-			"bosses": [{
-				"name": "The Weaver"
-			}]
-		}],
-		"The Vaal Ruins": [{
-			"act": 2,
-			"level": 20,
-			"town": false,
-			"waypoint": false,
-			"bosses": [
-
-			]
-		}],
-		"The Wetlands": [{
-				"act": 2,
-				"level": 19,
-				"town": false,
-				"waypoint": true,
-				"bosses": [{
-					"name": "Oak, Skullbreaker"
-				}]
-			},
-			{
-				"act": 6,
-				"level": 48,
-				"town": false,
-				"waypoint": false,
-				"bosses": [{
-					"name": "Ryslatha, the Puppet Mistress"
-				}]
-			}
-		],
-		"The Dread Thicket": [{
-				"act": 2,
-				"level": 21,
-				"town": false,
-				"waypoint": false,
-				"bosses": [{
-						"name": "Nadia the Soothing"
-					},
-					{
-						"name": "Aidan the Frenzied"
-					}
-				]
-			},
-			{
-				"act": 7,
-				"level": 53,
-				"town": false,
-				"waypoint": false,
-				"bosses": [{
-						"name": "Gruthkul, Mother of Despair"
-					},
-					{
-						"name": "The Dreadstone"
-					}
-				]
-			}
-		],
-		"The Caverns": [{
-			"act": 2,
-			"level": 22,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-				"name": "Q'uru"
-			}]
-		}],
-		"The Ancient Pyramid": [{
-			"act": 2,
-			"level": 23,
-			"town": false,
-			"waypoint": false,
-			"bosses": [
-
-			]
-		}],
-		"The Fellshrine Ruins": [{
-				"act": 2,
-				"level": 16,
-				"town": false,
-				"waypoint": false,
-				"bosses": [{
-					"name": "Soulmourn"
-				}]
-			},
-			{
-				"act": 7,
-				"level": 51,
-				"town": false,
-				"waypoint": false,
-				"bosses": [{
-					"name": "Bundle of Woe"
-				}]
-			}
-		],
-		"The Sarn Encampment": [{
-				"act": 3,
-				"level": 33,
-				"town": true,
-				"waypoint": true,
-				"bosses": [
-
-				]
-			},
-			{
-				"act": 8,
-				"level": 60,
-				"town": true,
-				"waypoint": true,
-				"bosses": [
-
-				]
-			}
-		],
-		"The City of Sarn": [{
-			"act": 3,
-			"level": 23,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-				"name": "Guard Captain"
-			}]
-		}],
-		"The Slums": [{
-			"act": 3,
-			"level": 24,
-			"town": false,
-			"waypoint": false,
-			"bosses": [{
-				"name": "Perpetus"
-			}]
-		}],
-		"The Crematorium": [{
-			"act": 3,
-			"level": 25,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-					"name": "Hatebeat"
-				},
-				{
-					"name": "Piety"
-				}
-			]
-		}],
-		"The Marketplace": [{
-			"act": 3,
-			"level": 26,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-				"name": "Marceus the Defaced"
-			}]
-		}],
-		"The Catacombs": [{
-			"act": 3,
-			"level": 27,
-			"town": false,
-			"waypoint": false,
-			"bosses": [
-
-			]
-		}],
-		"The Battlefront": [{
-			"act": 3,
-			"level": 27,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-				"name": "Captain Aurelianus"
-			}]
-		}],
-		"The Solaris Temple Level 1": [{
-				"act": 3,
-				"level": 27,
-				"town": false,
-				"waypoint": true,
-				"bosses": [{
-						"name": "The Infernal Seal"
-					},
-					{
-						"name": "The Voltaic Seal"
-					}
-				]
-			},
-			{
-				"act": 8,
-				"level": 59,
-				"town": false,
-				"waypoint": true,
-				"bosses": [
-
-				]
-			}
-		],
-		"The Solaris Temple Level 2": [{
-				"act": 3,
-				"level": 28,
-				"town": false,
-				"waypoint": true,
-				"bosses": [{
-						"name": "Banner of Passion"
-					},
-					{
-						"name": "Banner of Knowledge"
-					},
-					{
-						"name": "Banner of Action"
-					}
-				]
-			},
-			{
-				"act": 8,
-				"level": 59,
-				"town": false,
-				"waypoint": false,
-				"bosses": [{
-					"name": "Dawn, Harbinger of Solaris"
-				}]
-			}
-		],
-		"The Docks": [{
-			"act": 3,
-			"level": 29,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-				"name": "The Shipyard Terror"
-			}]
-		}],
-		"The Sewers": [{
-			"act": 3,
-			"level": 26,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-				"name": "Gloomglut"
-			}]
-		}],
-		"The Ebony Barracks": [{
-			"act": 3,
-			"level": 29,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-				"name": "General Gravicius"
-			}]
-		}],
-		"The Lunaris Temple Level 1": [{
-				"act": 3,
-				"level": 29,
-				"town": false,
-				"waypoint": true,
-				"bosses": [{
-						"name": "Fleshrend, Grand Inquisitor"
-					},
-					{
-						"name": "Kole"
-					}
-				]
-			},
-			{
-				"act": 8,
-				"level": 59,
-				"town": false,
-				"waypoint": true,
-				"bosses": [
-
-				]
-			}
-		],
-		"The Lunaris Temple Level 2": [{
-				"act": 3,
-				"level": 30,
-				"town": false,
-				"waypoint": false,
-				"bosses": [{
-						"name": "Piety"
-					},
-					{
-						"name": "Spinecrack"
-					}
-				]
-			},
-			{
-				"act": 8,
-				"level": 59,
-				"town": false,
-				"waypoint": false,
-				"bosses": [{
-					"name": "Dusk, Harbinger of Lunaris"
-				}]
-			}
-		],
-		"The Imperial Gardens": [{
-			"act": 3,
-			"level": 30,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-					"name": "Thistlesage"
-				},
-				{
-					"name": "The Conqueror Wurm"
-				}
-			]
-		}],
-		"The Library": [{
-			"act": 3,
-			"level": 30,
-			"town": false,
-			"waypoint": true,
-			"bosses": [
-
-			]
-		}],
-		"The Archives": [{
-			"act": 3,
-			"level": 31,
-			"town": false,
-			"waypoint": false,
-			"bosses": [{
-				"name": "Trinian, Intellectus Prime"
-			}]
-		}],
-		"The Sceptre of God": [{
-			"act": 3,
-			"level": 32,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-				"name": "Caliga, Imperatrix"
-			}]
-		}],
-		"The Upper Sceptre of God": [{
-			"act": 3,
-			"level": 33,
-			"town": false,
-			"waypoint": false,
-			"bosses": [{
-					"name": "Paradisae Venenum"
-				},
-				{
-					"name": "Dominus, High Templar"
-				},
-				{
-					"name": "Draconarius Wilhelm Flamebrand"
-				},
-				{
-					"name": "Imperator Stantinus Bitterblade"
-				},
-				{
-					"name": "Compulsor Octavia Sparkfist"
-				}
-			]
-		}],
-		"Highgate": [{
-				"act": 4,
-				"level": 40,
-				"town": true,
-				"waypoint": true,
-				"bosses": [
-
-				]
-			},
-			{
-				"act": 9,
-				"level": 67,
-				"town": true,
-				"waypoint": true,
-				"bosses": [
-
-				]
-			}
-		],
-		"The Aqueduct": [{
-			"act": 4,
-			"level": 33,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-				"name": "The Hundred Foot Shadow"
-			}]
-		}],
-		"The Dried Lake": [{
-			"act": 4,
-			"level": 34,
-			"town": false,
-			"waypoint": false,
-			"bosses": [{
-					"name": "Voll, Emperor of Purity"
-				},
-				{
-					"name": "Nightwane"
-				}
-			]
-		}],
-		"The Mines Level 1": [{
-			"act": 4,
-			"level": 34,
-			"town": false,
-			"waypoint": false,
-			"bosses": [{
-					"name": "Pikerivet"
-				},
-				{
-					"name": "Voidscream"
-				}
-			]
-		}],
-		"The Mines Level 2": [{
-			"act": 4,
-			"level": 35,
-			"town": false,
-			"waypoint": false,
-			"bosses": [{
-					"name": "Hammerstorm"
-				},
-				{
-					"name": "Voidscream"
-				},
-				{
-					"name": "Pikerivet"
-				},
-				{
-					"name": "The Burning Man"
-				}
-			]
-		}],
-		"The Crystal Veins": [{
-			"act": 4,
-			"level": 36,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-					"name": "The Burning Man"
-				},
-				{
-					"name": "Hammerstorm"
-				}
-			]
-		}],
-		"Kaom's Dream": [{
-			"act": 4,
-			"level": 37,
-			"town": false,
-			"waypoint": false,
-			"bosses": [{
-					"name": "Torchoak Grove"
-				},
-				{
-					"name": "Triskeriaki"
-				}
-			]
-		}],
-		"Kaom's Stronghold": [{
-			"act": 4,
-			"level": 38,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-				"name": "King Kaom"
-			}]
-		}],
-		"Daresso's Dream": [{
-			"act": 4,
-			"level": 37,
-			"town": false,
-			"waypoint": false,
-			"bosses": [{
-					"name": "Barkhul"
-				},
-				{
-					"name": "Eyepecker"
-				},
-				{
-					"name": "Steelchaw"
-				}
-			]
-		}],
-		"The Grand Arena": [{
-			"act": 4,
-			"level": 38,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-					"name": "Daresso, King of Swords"
-				},
-				{
-					"name": "Rudiarius Felix"
-				},
-				{
-					"name": "Mevion"
-				},
-				{
-					"name": "Dimachaeri Cassius"
-				}
-			]
-		}],
-		"The Belly of the Beast Level 1": [{
-			"act": 4,
-			"level": 38,
-			"town": false,
-			"waypoint": false,
-			"bosses": [{
-				"name": "The Bone Queen"
-			}]
-		}],
-		"The Belly of the Beast Level 2": [{
-			"act": 4,
-			"level": 39,
-			"town": false,
-			"waypoint": false,
-			"bosses": [{
-				"name": "Piety, the Abomination"
-			}]
-		}],
-		"The Harvest": [{
-			"act": 4,
-			"level": 40,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-					"name": "Malachai, The Nightmare"
-				},
-				{
-					"name": "Doedre Darktongue"
-				},
-				{
-					"name": "Maligaro, The Inquisitor"
-				},
-				{
-					"name": "Shavronne of Umbra"
-				}
-			]
-		}],
-		"The Ascent": [{
-			"act": 4,
-			"level": 40,
-			"town": false,
-			"waypoint": false,
-			"bosses": [{
-				"name": "The White Death"
-			}]
-		}],
-		"Overseer's Tower": [{
-			"act": 5,
-			"level": 45,
-			"town": true,
-			"waypoint": true,
-			"bosses": [
-
-			]
-		}],
-		"The Slave Pens": [{
-			"act": 5,
-			"level": 41,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-				"name": "Overseer Krow"
-			}]
-		}],
-		"The Control Blocks": [{
-				"act": 5,
-				"level": 41,
-				"town": false,
-				"waypoint": false,
-				"bosses": [{
-					"name": "Justicar Casticus"
-				}]
-			},
-			{
-				"act": 10,
-				"level": 66,
-				"town": false,
-				"waypoint": true,
-				"bosses": [{
-					"name": "Vilenta"
-				}]
-			}
-		],
-		"Oriath Square": [{
-			"act": 5,
-			"level": 42,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-					"name": "The Matriarch"
-				},
-				{
-					"name": "Oriath Enforcer"
-				}
-			]
-		}],
-		"The Ruined Square": [{
-			"act": 5,
-			"level": 44,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-					"name": "Utula, Stone and Steel"
-				},
-				{
-					"name": "The Risen Matriarch"
-				}
-			]
-		}],
-		"The Templar Courts": [{
-			"act": 5,
-			"level": 42,
-			"town": false,
-			"waypoint": true,
-			"bosses": [
-
-			]
-		}],
-		"The Torched Courts": [{
-				"act": 5,
-				"level": 44,
-				"town": false,
-				"waypoint": false,
-				"bosses": [{
-					"name": "Cato, Scholar of Light"
-				}]
-			},
-			{
-				"act": 10,
-				"level": 65,
-				"town": false,
-				"waypoint": false,
-				"bosses": [
-
-				]
-			}
-		],
-		"The Chamber of Innocence": [{
-			"act": 5,
-			"level": 43,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-				"name": "High Templar Avarius"
-			}]
-		}],
-		"The Ossuary": [{
-				"act": 5,
-				"level": 44,
-				"town": false,
-				"waypoint": false,
-				"bosses": [
-
-				]
-			},
-			{
-				"act": 10,
-				"level": 67,
-				"town": false,
-				"waypoint": false,
-				"bosses": [
-
-				]
-			}
-		],
-		"The Reliquary": [{
-				"act": 5,
-				"level": 44,
-				"town": false,
-				"waypoint": true,
-				"bosses": [
-
-				]
-			},
-			{
-				"act": 10,
-				"level": 67,
-				"town": false,
-				"waypoint": true,
-				"bosses": [
-
-				]
-			}
-		],
-		"The Cathedral Rooftop": [{
-				"act": 5,
-				"level": 45,
-				"town": false,
-				"waypoint": true,
-				"bosses": [{
-					"name": "Kitava, the Insatiable"
-				}]
-			},
-			{
-				"act": 10,
-				"level": 64,
-				"town": false,
-				"waypoint": false,
-				"bosses": [
-
-				]
-			}
-		],
-		"The Karui Fortress": [{
-			"act": 6,
-			"level": 46,
-			"town": false,
-			"waypoint": false,
-			"bosses": [{
-				"name": "Tukohama, Karui God of War"
-			}]
-		}],
-		"The Ridge": [{
-			"act": 6,
-			"level": 46,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-				"name": "Fleetfreak"
-			}]
-		}],
-		"Shavronne's Tower": [{
-			"act": 6,
-			"level": 47,
-			"town": false,
-			"waypoint": false,
-			"bosses": [{
-					"name": "Shavronne the Returned"
-				},
-				{
-					"name": "Reassembled Brutus"
-				}
-			]
-		}],
-		"The Beacon": [{
-			"act": 6,
-			"level": 49,
-			"town": false,
-			"waypoint": true,
-			"bosses": [
-
-			]
-		}],
-		"The Brine King's Reef": [{
-			"act": 6,
-			"level": 50,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-				"name": "Tsoagoth, The Brine King"
-			}]
-		}],
-		"The Bridge Encampment": [{
-			"act": 7,
-			"level": 55,
-			"town": true,
-			"waypoint": true,
-			"bosses": [
-
-			]
-		}],
-		"The Crypt": [{
-			"act": 7,
-			"level": 51,
-			"town": false,
-			"waypoint": true,
-			"bosses": [
-
-			]
-		}],
-		"Maligaro's Sanctum": [{
-			"act": 7,
-			"level": 52,
-			"town": false,
-			"waypoint": false,
-			"bosses": [{
-					"name": "Maligaro, the Artist"
-				},
-				{
-					"name": "Black Death, Pain Unending"
-				},
-				{
-					"name": "Fidelitas, Loyalty Undying"
-				}
-			]
-		}],
-		"The Ashen Fields": [{
-			"act": 7,
-			"level": 53,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-					"name": "Greust, Lord of the Forest"
-				},
-				{
-					"name": "Oak"
-				},
-				{
-					"name": "Alira"
-				},
-				{
-					"name": "Kraityn"
-				}
-			]
-		}],
-		"The Causeway": [{
-			"act": 7,
-			"level": 54,
-			"town": false,
-			"waypoint": true,
-			"bosses": [
-
-			]
-		}],
-		"The Vaal City": [{
-			"act": 7,
-			"level": 54,
-			"town": false,
-			"waypoint": true,
-			"bosses": [
-
-			]
-		}],
-		"The Temple of Decay Level 1": [{
-			"act": 7,
-			"level": 54,
-			"town": false,
-			"waypoint": false,
-			"bosses": [{
-				"name": "Blightblade"
-			}]
-		}],
-		"The Temple of Decay Level 2": [{
-			"act": 7,
-			"level": 55,
-			"town": false,
-			"waypoint": false,
-			"bosses": [{
-				"name": "Arakaali, Spinner of Shadows"
-			}]
-		}],
-		"The Sarn Ramparts": [{
-			"act": 8,
-			"level": 55,
-			"town": false,
-			"waypoint": true,
-			"bosses": [
-
-			]
-		}],
-		"The Toxic Conduits": [{
-			"act": 8,
-			"level": 56,
-			"town": false,
-			"waypoint": false,
-			"bosses": [{
-				"name": "Lingering Aberration"
-			}]
-		}],
-		"Doedre's Cesspool": [{
-			"act": 8,
-			"level": 56,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-				"name": "Doedre the Vile"
-			}]
-		}],
-		"The Grand Promenade": [{
-			"act": 8,
-			"level": 56,
-			"town": false,
-			"waypoint": false,
-			"bosses": [{
-				"name": "Ondar, the Betrayer"
-			}]
-		}],
-		"The High Gardens": [{
-			"act": 8,
-			"level": 58,
-			"town": false,
-			"waypoint": false,
-			"bosses": [{
-				"name": "Yugul, Reflection of Terror"
-			}]
-		}],
-		"The Bath House": [{
-			"act": 8,
-			"level": 57,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-				"name": "Hector Titucius, Eternal Servant"
-			}]
-		}],
-		"The Lunaris Concourse": [{
-			"act": 8,
-			"level": 58,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-				"name": "Nightbringer Lucius"
-			}]
-		}],
-		"The Quay": [{
-			"act": 8,
-			"level": 57,
-			"town": false,
-			"waypoint": false,
-			"bosses": [{
-				"name": "Tolman"
-			}]
-		}],
-		"The Grain Gate": [{
-			"act": 8,
-			"level": 57,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-					"name": "Gemling Legionnaire"
-				},
-				{
-					"name": "Gemling Captain"
-				}
-			]
-		}],
-		"The Imperial Fields": [{
-			"act": 8,
-			"level": 58,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-				"name": "Effigy of Fear"
-			}]
-		}],
-		"The Solaris Concourse": [{
-			"act": 8,
-			"level": 58,
-			"town": false,
-			"waypoint": true,
-			"bosses": [
-
-			]
-		}],
-		"The Harbour Bridge": [{
-			"act": 8,
-			"level": 60,
-			"town": false,
-			"waypoint": false,
-			"bosses": [{
-					"name": "Lunaris, Eternal Moon"
-				},
-				{
-					"name": "Solaris, Eternal Sun"
-				}
-			]
-		}],
-		"The Blood Aqueduct": [{
-			"act": 9,
-			"level": 61,
-			"town": false,
-			"waypoint": true,
-			"bosses": [
-
-			]
-		}],
-		"The Descent": [{
-			"act": 9,
-			"level": 61,
-			"town": false,
-			"waypoint": false,
-			"bosses": [
-
-			]
-		}],
-		"The Vastiri Desert": [{
-			"act": 9,
-			"level": 61,
-			"town": false,
-			"waypoint": true,
-			"bosses": [
-
-			]
-		}],
-		"The Oasis": [{
-			"act": 9,
-			"level": 61,
-			"town": false,
-			"waypoint": false,
-			"bosses": [{
-				"name": "Shakari, Queen of the Sands"
-			}]
-		}],
-		"The Foothills": [{
-			"act": 9,
-			"level": 62,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-				"name": "Boulderback"
-			}]
-		}],
-		"The Boiling Lake": [{
-			"act": 9,
-			"level": 62,
-			"town": false,
-			"waypoint": false,
-			"bosses": [{
-				"name": "The Basilisk"
-			}]
-		}],
-		"The Tunnel": [{
-			"act": 9,
-			"level": 62,
-			"town": false,
-			"waypoint": true,
-			"bosses": [
-
-			]
-		}],
-		"The Quarry": [{
-			"act": 9,
-			"level": 63,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-				"name": "Garukhan, Queen of the Winds"
-			}]
-		}],
-		"The Refinery": [{
-			"act": 9,
-			"level": 63,
-			"town": false,
-			"waypoint": false,
-			"bosses": [{
-				"name": "General Adus"
-			}]
-		}],
-		"The Belly of the Beast": [{
-			"act": 9,
-			"level": 63,
-			"town": false,
-			"waypoint": false,
-			"bosses": [{
-				"name": "Droolmaw"
-			}]
-		}],
-		"The Rotting Core": [{
-			"act": 9,
-			"level": 64,
-			"town": false,
-			"waypoint": false,
-			"bosses": [{
-					"name": "The Depraved Trinity"
-				},
-				{
-					"name": "Doedre, Darksoul"
-				},
-				{
-					"name": "Maligaro, The Broken"
-				},
-				{
-					"name": "Shavronne, Unbound"
-				}
-			]
-		}],
-		"Oriath Docks": [{
-			"act": 10,
-			"level": 69,
-			"town": true,
-			"waypoint": true,
-			"bosses": [
-
-			]
-		}],
-		"The Ravaged Square": [{
-			"act": 10,
-			"level": 64,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-				"name": "The Rotten Matriarch"
-			}]
-		}],
-		"The Desecrated Chambers": [{
-			"act": 10,
-			"level": 65,
-			"town": false,
-			"waypoint": true,
-			"bosses": [{
-				"name": "Avarius, Reassembled"
-			}]
-		}],
-		"The Canals": [{
-			"act": 10,
-			"level": 66,
-			"town": false,
-			"waypoint": false,
-			"bosses": [
-
-			]
-		}],
-		"The Feeding Trough": [{
-			"act": 10,
-			"level": 67,
-			"town": false,
-			"waypoint": false,
-			"bosses": [{
-				"name": "Kitava, the Insatiable"
-			}]
-		}],
-		"Oriath": [{
-			"act": 11,
-			"level": 69,
-			"town": true,
-			"waypoint": true,
-			"bosses": [
-
-			]
-		}],
-		"The Templar Laboratory": [{
-			"act": 11,
-			"level": 68,
-			"town": false,
-			"waypoint": true,
-			"bosses": [
-
-			]
-		}]
-	},
-	"vaal": {
-		"Strange Sinkhole": {
-			"bosses": [
-				[
-					"Mother of the Hive"
-				]
-			]
-		},
-		"Concealed Cavity": {
-			"bosses": [
-				[
-					"The All-seeing Eye"
-				]
-			]
-		},
-		"Sunken Shingle": {
-			"bosses": [
-				[
-					"Perquil the Lucky"
-				]
-			]
-		},
-		"Clouded Ridge": {
-			"bosses": [
-				[
-					"Konu, Maker of Wind"
-				]
-			]
-		},
-		"Forgotten Oubliette": {
-			"bosses": [
-				[
-					"Coniraya, Shadow of Malice"
-				]
-			]
-		},
-		"Remote Gulch": {
-			"bosses": [
-				[
-					"Sheaq, Maker of Floods"
-				]
-			]
-		},
-		"Narrow Ravine": {
-			"bosses": [
-				[
-					"Kamaq, Soilmaker"
-				]
-			]
-		},
-		"Mystical Clearing": {
-			"bosses": [
-				[
-					"Simi, the Nature Touched"
-				]
-			]
-		},
-		"Covered-up Hollow": {
-			"bosses": [
-				[
-					"Cintiq, the Inescapable"
-				]
-			]
-		},
-		"Hidden Patch": {
-			"bosses": [
-				[
-					"Thornrunner"
-				]
-			]
-		},
-		"Entombed Alcove": {
-			"bosses": [
-				[
-					"Shrapnelbearer"
-				]
-			]
-		},
-		"Secret Laboratory": {
-			"bosses": [
-				[
-					"Atziri's Pride"
-				]
-			]
-		},
-		"Secluded Copse": {
-			"bosses": [
-				[
-					"Kutec, Vaal Fleshsmith"
-				]
-			]
-		},
-		"Forbidden Chamber": {
-			"bosses": [
-				[
-					"Haviri, Vaal Metalsmith"
-				]
-			]
-		},
-		"Quarantined Quarters": {
-			"bosses": [
-				[
-					"The Sunburst Queen"
-				]
-			]
-		},
-		"Disused Furnace": {
-			"bosses": [
-				[
-					"Curator Miem"
-				]
-			]
-		},
-		"Blind Alley": {
-			"bosses": [
-				[
-					"M'gaska, the Living Pyre"
-				]
-			]
-		},
-		"Entombed Chamber": {
-			"bosses": [
-				[
-					"Ossecati, Boneshaper"
-				]
-			]
-		},
-		"Sacred Chambers": {
-			"bosses": [
-				[
-					"Shadow of Vengeance"
-				]
-			]
-		},
-		"Stagnant Canal": {
-			"bosses": [
-				[
-					"Wiraqucha, Ancient Guardian"
-				]
-			]
-		},
-		"Walled-off Ducts": {
-			"bosses": [
-				[
-					"Cava, Artist of Pain"
-				]
-			]
-		},
-		"Neglected Cellar": {
-			"bosses": [
-				[
-					"Rima, Deep Temptress"
-				]
-			]
-		},
-		"Arcane Chambers": {
-			"bosses": [
-				[
-					"Beheader Ataguchu"
-				]
-			]
-		},
-		"Inner Grounds": {
-			"bosses": [
-				[
-					"Inti of the Blood Moon"
-				]
-			]
-		},
-		"Sealed Corridors": {
-			"bosses": [
-				[
-					"Wiraq, the Impaler"
-				]
-			]
-		},
-		"Restricted Gallery": {
-			"bosses": [
-				[
-					"Ch'aska, Maker of Rain"
-				]
-			]
-		},
-		"Forgotten Conduit": {
-			"bosses": [
-				[
-					"Torrent of Fear"
-				]
-			]
-		},
-		"Ancient Catacomb": {
-			"bosses": [
-				[
-					"Commander of Flesh"
-				]
-			]
-		},
-		"Haunted Mineshaft": {
-			"bosses": [
-				[
-					"Calxipher"
-				]
-			]
-		},
-		"Abandoned Dam": {
-			"bosses": [
-				[
-					"Quetzerxi"
-				]
-			]
-		},
-		"Desolate Track": {
-			"bosses": [
-				[
-					"Quetzerxi"
-				]
-			]
-		},
-		"Reclaimed Barracks": {
-			"bosses": [
-				[
-					"Huitepa the Blind"
-				]
-			]
-		},
-		"Sealed Basement": {
-			"bosses": [
-				[
-					"Guraq, Daylight's Blade"
-				]
-			]
-		},
-		"Secluded Canal": {
-			"bosses": [
-				[
-					"Xuatl, Cutting Wind"
-				]
-			]
-		},
-		"Forbidden Archives": {
-			"bosses": [
-				[
-					"Exartze, the Woven Stone"
-				]
-			]
-		},
-		"Cremated Archives": {
-			"bosses": [
-				[
-					"Exartze, the Woven Stone"
-				]
-			]
-		},
-		"Twisted Inquisitorium": {
-			"bosses": [
-				[
-					"Anacuacotli, Death's Worship"
-				]
-			]
-		},
-		"Deathly Chambers": {
-			"bosses": [
-				[
-					"Harbinger of Disorder"
-				]
-			]
-		},
-		"Restricted Collection": {
-			"bosses": [
-				[
-					"Iorphia, Dream Eater"
-				]
-			]
-		},
-		"Side Chapel": {
-			"bosses": [
-				[
-					"Daluatti, Stoneraiser"
-				]
-			]
-		},
-		"Radiant Pools": {
-			"bosses": [
-				[
-					"Perquil the Lucky"
-				]
-			]
-		},
-		"Clouded Ledge": {
-			"bosses": [
-				[
-					"Simi, the Nature Touched"
-				]
-			]
-		},
-		"Sealed Repository": {
-			"bosses": [
-				[
-					"Inti of the Blood Moon"
-				]
-			]
-		},
-		"Flooded Complex": {
-			"bosses": [
-				[
-					"M'gaska, the Living Pyre"
-				]
-			]
-		},
-		"Forbidden Shrine": {
-			"bosses": [
-				[
-					"Shrapnelbearer"
-				]
-			]
-		},
-		"Evacuated Quarter": {
-			"bosses": [
-				[
-					"Curator Miem"
-				]
-			]
-		},
-		"Concealed Caldarium": {
-			"bosses": [
-				[
-					"Cava, Artist of Pain"
-				]
-			]
-		},
-		"Moonlit Chambers": {
-			"bosses": [
-				[
-					"Beheader Ataguchu"
-				]
-			]
-		},
-		"Shifting Sands": {
-			"bosses": [
-				[
-					"Wiraq, the Impaler"
-				]
-			]
-		},
-		"Forgotten Gulch": {
-			"bosses": [
-				[
-					"Curator Miem"
-				]
-			]
-		},
-		"Desolate Isle": {
-			"bosses": [
-				[
-					"Wiraqucha, Ancient Guardian"
-				]
-			]
-		},
-		"Dusty Bluff": {
-			"bosses": [
-				[
-					"Quetzerxi"
-				]
-			]
-		}
-	},
-	"labyrinth": {
-		"Aspirants' Plaza": {
-			"trial": false
-		},
-		"Trial of Piercing Truth": {
-			"trial": true
-		},
-		"Trial of Swirling Fear": {
-			"trial": true
-		},
-		"Trial of Crippling Grief": {
-			"trial": true
-		},
-		"Trial of Burning Rage": {
-			"trial": true
-		},
-		"Trial of Lingering Pain": {
-			"trial": true
-		},
-		"Trial of Stinging Doubt": {
-			"trial": true
-		}
-	}
+  "area": {
+    "Unearthed Hideout": [
+      {
+        "act": 1,
+        "level": 20,
+        "town": false,
+        "waypoint": true,
+        "bosses": []
+      }
+    ],
+    "Enlightened Hideout": [
+      {
+        "act": 1,
+        "level": 20,
+        "town": false,
+        "waypoint": true,
+        "bosses": []
+      }
+    ],
+    "Coastal Hideout": [
+      {
+        "act": 1,
+        "level": 20,
+        "town": false,
+        "waypoint": true,
+        "bosses": []
+      }
+    ],
+    "Overgrown Hideout": [
+      {
+        "act": 1,
+        "level": 20,
+        "town": false,
+        "waypoint": true,
+        "bosses": []
+      }
+    ],
+    "Lush Hideout": [
+      {
+        "act": 1,
+        "level": 20,
+        "town": false,
+        "waypoint": true,
+        "bosses": []
+      }
+    ],
+    "Battle-scarred Hideout": [
+      {
+        "act": 1,
+        "level": 20,
+        "town": false,
+        "waypoint": true,
+        "bosses": []
+      }
+    ],
+    "Backstreet Hideout": [
+      {
+        "act": 1,
+        "level": 20,
+        "town": false,
+        "waypoint": true,
+        "bosses": []
+      }
+    ],
+    "Immaculate Hideout": [
+      {
+        "act": 1,
+        "level": 20,
+        "town": false,
+        "waypoint": true,
+        "bosses": []
+      }
+    ],
+    "Lioneye's Watch": [
+      {
+        "act": 1,
+        "level": 13,
+        "town": true,
+        "waypoint": true,
+        "bosses": []
+      },
+      {
+        "act": 6,
+        "level": 50,
+        "town": true,
+        "waypoint": true,
+        "bosses": []
+      }
+    ],
+    "The Twilight Strand": [
+      {
+        "act": 1,
+        "level": 1,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Hillock"
+          }
+        ]
+      },
+      {
+        "act": 6,
+        "level": 45,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Rhys of Abram"
+          }
+        ]
+      }
+    ],
+    "The Coast": [
+      {
+        "act": 1,
+        "level": 2,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Fire Fury"
+          }
+        ]
+      },
+      {
+        "act": 6,
+        "level": 45,
+        "town": false,
+        "waypoint": true,
+        "bosses": []
+      }
+    ],
+    "The Tidal Island": [
+      {
+        "act": 1,
+        "level": 3,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Hailrake"
+          }
+        ]
+      },
+      {
+        "act": 6,
+        "level": 45,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Riptide"
+          }
+        ]
+      }
+    ],
+    "The Mud Flats": [
+      {
+        "act": 1,
+        "level": 4,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Oozeback Bloom"
+          }
+        ]
+      },
+      {
+        "act": 6,
+        "level": 46,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "The Dishonoured Queen"
+          },
+          {
+            "name": "Forgotten Warrior"
+          }
+        ]
+      }
+    ],
+    "The Fetid Pool": [
+      {
+        "act": 1,
+        "level": 5,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Kadavrus the Defiler"
+          }
+        ]
+      }
+    ],
+    "The Flooded Depths": [
+      {
+        "act": 1,
+        "level": 6,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "The Deep Dweller"
+          }
+        ]
+      }
+    ],
+    "The Submerged Passage": [
+      {
+        "act": 1,
+        "level": 5,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Brood Princess"
+          }
+        ]
+      }
+    ],
+    "The Ledge": [
+      {
+        "act": 1,
+        "level": 6,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Kuduku, the False God"
+          }
+        ]
+      }
+    ],
+    "The Climb": [
+      {
+        "act": 1,
+        "level": 7,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Ironpoint the Forsaken"
+          },
+          {
+            "name": "The Faun"
+          }
+        ]
+      }
+    ],
+    "The Lower Prison": [
+      {
+        "act": 1,
+        "level": 8,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Chatters"
+          }
+        ]
+      },
+      {
+        "act": 6,
+        "level": 47,
+        "town": false,
+        "waypoint": true,
+        "bosses": []
+      }
+    ],
+    "The Upper Prison": [
+      {
+        "act": 1,
+        "level": 9,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Sawbones"
+          },
+          {
+            "name": "Brutus, Lord Incarcerator"
+          }
+        ]
+      }
+    ],
+    "Prisoner's Gate": [
+      {
+        "act": 1,
+        "level": 10,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Ungulath"
+          },
+          {
+            "name": "The Burning Menace"
+          }
+        ]
+      },
+      {
+        "act": 6,
+        "level": 47,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Abberath, the Cloven One"
+          }
+        ]
+      }
+    ],
+    "The Ship Graveyard": [
+      {
+        "act": 1,
+        "level": 11,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Captain Fairgraves"
+          }
+        ]
+      }
+    ],
+    "The Ship Graveyard Cave": [
+      {
+        "act": 1,
+        "level": 12,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Stranglecharm"
+          }
+        ]
+      }
+    ],
+    "The Cavern of Wrath": [
+      {
+        "act": 1,
+        "level": 12,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Amarissa, Daughter of Merveil"
+          }
+        ]
+      }
+    ],
+    "The Cavern of Anger": [
+      {
+        "act": 1,
+        "level": 13,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Ambrosia, Daughter of Merveil"
+          },
+          {
+            "name": "Merveil, the Siren"
+          }
+        ]
+      },
+      {
+        "act": 6,
+        "level": 49,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Brinecrack"
+          }
+        ]
+      }
+    ],
+    "The Forest Encampment": [
+      {
+        "act": 2,
+        "level": 23,
+        "town": true,
+        "waypoint": true,
+        "bosses": []
+      }
+    ],
+    "The Southern Forest": [
+      {
+        "act": 2,
+        "level": 13,
+        "town": false,
+        "waypoint": true,
+        "bosses": []
+      },
+      {
+        "act": 6,
+        "level": 49,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Hollowskull, the Willing Host"
+          }
+        ]
+      }
+    ],
+    "The Old Fields": [
+      {
+        "act": 2,
+        "level": 14,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Gneiss"
+          }
+        ]
+      }
+    ],
+    "The Den": [
+      {
+        "act": 2,
+        "level": 15,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "The Great White Beast"
+          }
+        ]
+      },
+      {
+        "act": 7,
+        "level": 53,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "The Great White Bones"
+          },
+          {
+            "name": "The Bone Sculptor"
+          }
+        ]
+      }
+    ],
+    "The Crossroads": [
+      {
+        "act": 2,
+        "level": 15,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Bravalo"
+          }
+        ]
+      },
+      {
+        "act": 7,
+        "level": 51,
+        "town": false,
+        "waypoint": true,
+        "bosses": []
+      }
+    ],
+    "The Crypt Level 1": [
+      {
+        "act": 2,
+        "level": 17,
+        "town": false,
+        "waypoint": true,
+        "bosses": []
+      }
+    ],
+    "The Crypt Level 2": [
+      {
+        "act": 2,
+        "level": 18,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Archbishop Geofri the Abashed"
+          }
+        ]
+      }
+    ],
+    "The Chamber of Sins Level 1": [
+      {
+        "act": 2,
+        "level": 15,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Black Death"
+          }
+        ]
+      },
+      {
+        "act": 7,
+        "level": 52,
+        "town": false,
+        "waypoint": true,
+        "bosses": []
+      }
+    ],
+    "The Chamber of Sins Level 2": [
+      {
+        "act": 2,
+        "level": 16,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Fidelitas, the Mourning"
+          }
+        ]
+      },
+      {
+        "act": 7,
+        "level": 52,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Plague Retch"
+          }
+        ]
+      }
+    ],
+    "The Broken Bridge": [
+      {
+        "act": 2,
+        "level": 16,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Kraityn, Scarbearer"
+          }
+        ]
+      },
+      {
+        "act": 7,
+        "level": 50,
+        "town": false,
+        "waypoint": false,
+        "bosses": []
+      }
+    ],
+    "The Riverways": [
+      {
+        "act": 2,
+        "level": 15,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Targa, Beast Poacher"
+          }
+        ]
+      },
+      {
+        "act": 6,
+        "level": 48,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "The Animal Pack"
+          }
+        ]
+      }
+    ],
+    "The Northern Forest": [
+      {
+        "act": 2,
+        "level": 21,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Seleslatha"
+          }
+        ]
+      },
+      {
+        "act": 7,
+        "level": 53,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Tunnelworm"
+          }
+        ]
+      }
+    ],
+    "The Western Forest": [
+      {
+        "act": 2,
+        "level": 17,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Alira Darktongue"
+          },
+          {
+            "name": "Captain Arteri"
+          }
+        ]
+      },
+      {
+        "act": 6,
+        "level": 48,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Defiled Proclamation"
+          }
+        ]
+      }
+    ],
+    "The Weaver's Chambers": [
+      {
+        "act": 2,
+        "level": 18,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "The Weaver"
+          }
+        ]
+      }
+    ],
+    "The Vaal Ruins": [
+      {
+        "act": 2,
+        "level": 20,
+        "town": false,
+        "waypoint": false,
+        "bosses": []
+      }
+    ],
+    "The Wetlands": [
+      {
+        "act": 2,
+        "level": 19,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Oak, Skullbreaker"
+          }
+        ]
+      },
+      {
+        "act": 6,
+        "level": 48,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Ryslatha, the Puppet Mistress"
+          }
+        ]
+      }
+    ],
+    "The Dread Thicket": [
+      {
+        "act": 2,
+        "level": 21,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Nadia the Soothing"
+          },
+          {
+            "name": "Aidan the Frenzied"
+          }
+        ]
+      },
+      {
+        "act": 7,
+        "level": 53,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Gruthkul, Mother of Despair"
+          },
+          {
+            "name": "The Dreadstone"
+          }
+        ]
+      }
+    ],
+    "The Caverns": [
+      {
+        "act": 2,
+        "level": 22,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Q'uru"
+          }
+        ]
+      }
+    ],
+    "The Ancient Pyramid": [
+      {
+        "act": 2,
+        "level": 23,
+        "town": false,
+        "waypoint": false,
+        "bosses": []
+      }
+    ],
+    "The Fellshrine Ruins": [
+      {
+        "act": 2,
+        "level": 16,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Soulmourn"
+          }
+        ]
+      },
+      {
+        "act": 7,
+        "level": 51,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Bundle of Woe"
+          }
+        ]
+      }
+    ],
+    "The Sarn Encampment": [
+      {
+        "act": 3,
+        "level": 33,
+        "town": true,
+        "waypoint": true,
+        "bosses": []
+      },
+      {
+        "act": 8,
+        "level": 60,
+        "town": true,
+        "waypoint": true,
+        "bosses": []
+      }
+    ],
+    "The City of Sarn": [
+      {
+        "act": 3,
+        "level": 23,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Guard Captain"
+          }
+        ]
+      }
+    ],
+    "The Slums": [
+      {
+        "act": 3,
+        "level": 24,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Perpetus"
+          }
+        ]
+      }
+    ],
+    "The Crematorium": [
+      {
+        "act": 3,
+        "level": 25,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Hatebeat"
+          },
+          {
+            "name": "Piety"
+          }
+        ]
+      }
+    ],
+    "The Marketplace": [
+      {
+        "act": 3,
+        "level": 26,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Marceus the Defaced"
+          }
+        ]
+      }
+    ],
+    "The Catacombs": [
+      {
+        "act": 3,
+        "level": 27,
+        "town": false,
+        "waypoint": false,
+        "bosses": []
+      }
+    ],
+    "The Battlefront": [
+      {
+        "act": 3,
+        "level": 27,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Captain Aurelianus"
+          }
+        ]
+      }
+    ],
+    "The Solaris Temple Level 1": [
+      {
+        "act": 3,
+        "level": 27,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "The Infernal Seal"
+          },
+          {
+            "name": "The Voltaic Seal"
+          }
+        ]
+      },
+      {
+        "act": 8,
+        "level": 59,
+        "town": false,
+        "waypoint": true,
+        "bosses": []
+      }
+    ],
+    "The Solaris Temple Level 2": [
+      {
+        "act": 3,
+        "level": 28,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Banner of Passion"
+          },
+          {
+            "name": "Banner of Knowledge"
+          },
+          {
+            "name": "Banner of Action"
+          }
+        ]
+      },
+      {
+        "act": 8,
+        "level": 59,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Dawn, Harbinger of Solaris"
+          }
+        ]
+      }
+    ],
+    "The Docks": [
+      {
+        "act": 3,
+        "level": 29,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "The Shipyard Terror"
+          }
+        ]
+      }
+    ],
+    "The Sewers": [
+      {
+        "act": 3,
+        "level": 26,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Gloomglut"
+          }
+        ]
+      }
+    ],
+    "The Ebony Barracks": [
+      {
+        "act": 3,
+        "level": 29,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "General Gravicius"
+          }
+        ]
+      }
+    ],
+    "The Lunaris Temple Level 1": [
+      {
+        "act": 3,
+        "level": 29,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Fleshrend, Grand Inquisitor"
+          },
+          {
+            "name": "Kole"
+          }
+        ]
+      },
+      {
+        "act": 8,
+        "level": 59,
+        "town": false,
+        "waypoint": true,
+        "bosses": []
+      }
+    ],
+    "The Lunaris Temple Level 2": [
+      {
+        "act": 3,
+        "level": 30,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Piety"
+          },
+          {
+            "name": "Spinecrack"
+          }
+        ]
+      },
+      {
+        "act": 8,
+        "level": 59,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Dusk, Harbinger of Lunaris"
+          }
+        ]
+      }
+    ],
+    "The Imperial Gardens": [
+      {
+        "act": 3,
+        "level": 30,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Thistlesage"
+          },
+          {
+            "name": "The Conqueror Wurm"
+          }
+        ]
+      }
+    ],
+    "The Library": [
+      {
+        "act": 3,
+        "level": 30,
+        "town": false,
+        "waypoint": true,
+        "bosses": []
+      }
+    ],
+    "The Archives": [
+      {
+        "act": 3,
+        "level": 31,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Trinian, Intellectus Prime"
+          }
+        ]
+      }
+    ],
+    "The Sceptre of God": [
+      {
+        "act": 3,
+        "level": 32,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Caliga, Imperatrix"
+          }
+        ]
+      }
+    ],
+    "The Upper Sceptre of God": [
+      {
+        "act": 3,
+        "level": 33,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Paradisae Venenum"
+          },
+          {
+            "name": "Dominus, High Templar"
+          },
+          {
+            "name": "Draconarius Wilhelm Flamebrand"
+          },
+          {
+            "name": "Imperator Stantinus Bitterblade"
+          },
+          {
+            "name": "Compulsor Octavia Sparkfist"
+          }
+        ]
+      }
+    ],
+    "Highgate": [
+      {
+        "act": 4,
+        "level": 40,
+        "town": true,
+        "waypoint": true,
+        "bosses": []
+      },
+      {
+        "act": 9,
+        "level": 67,
+        "town": true,
+        "waypoint": true,
+        "bosses": []
+      }
+    ],
+    "The Aqueduct": [
+      {
+        "act": 4,
+        "level": 33,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "The Hundred Foot Shadow"
+          }
+        ]
+      }
+    ],
+    "The Dried Lake": [
+      {
+        "act": 4,
+        "level": 34,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Voll, Emperor of Purity"
+          },
+          {
+            "name": "Nightwane"
+          }
+        ]
+      }
+    ],
+    "The Mines Level 1": [
+      {
+        "act": 4,
+        "level": 34,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Pikerivet"
+          },
+          {
+            "name": "Voidscream"
+          }
+        ]
+      }
+    ],
+    "The Mines Level 2": [
+      {
+        "act": 4,
+        "level": 35,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Hammerstorm"
+          },
+          {
+            "name": "Voidscream"
+          },
+          {
+            "name": "Pikerivet"
+          },
+          {
+            "name": "The Burning Man"
+          }
+        ]
+      }
+    ],
+    "The Crystal Veins": [
+      {
+        "act": 4,
+        "level": 36,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "The Burning Man"
+          },
+          {
+            "name": "Hammerstorm"
+          }
+        ]
+      }
+    ],
+    "Kaom's Dream": [
+      {
+        "act": 4,
+        "level": 37,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Torchoak Grove"
+          },
+          {
+            "name": "Triskeriaki"
+          }
+        ]
+      }
+    ],
+    "Kaom's Stronghold": [
+      {
+        "act": 4,
+        "level": 38,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "King Kaom"
+          }
+        ]
+      }
+    ],
+    "Daresso's Dream": [
+      {
+        "act": 4,
+        "level": 37,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Barkhul"
+          },
+          {
+            "name": "Eyepecker"
+          },
+          {
+            "name": "Steelchaw"
+          }
+        ]
+      }
+    ],
+    "The Grand Arena": [
+      {
+        "act": 4,
+        "level": 38,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Daresso, King of Swords"
+          },
+          {
+            "name": "Rudiarius Felix"
+          },
+          {
+            "name": "Mevion"
+          },
+          {
+            "name": "Dimachaeri Cassius"
+          }
+        ]
+      }
+    ],
+    "The Belly of the Beast Level 1": [
+      {
+        "act": 4,
+        "level": 38,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "The Bone Queen"
+          }
+        ]
+      }
+    ],
+    "The Belly of the Beast Level 2": [
+      {
+        "act": 4,
+        "level": 39,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Piety, the Abomination"
+          }
+        ]
+      }
+    ],
+    "The Harvest": [
+      {
+        "act": 4,
+        "level": 40,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Malachai, The Nightmare"
+          },
+          {
+            "name": "Doedre Darktongue"
+          },
+          {
+            "name": "Maligaro, The Inquisitor"
+          },
+          {
+            "name": "Shavronne of Umbra"
+          }
+        ]
+      }
+    ],
+    "The Ascent": [
+      {
+        "act": 4,
+        "level": 40,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "The White Death"
+          }
+        ]
+      }
+    ],
+    "Overseer's Tower": [
+      {
+        "act": 5,
+        "level": 45,
+        "town": true,
+        "waypoint": true,
+        "bosses": []
+      }
+    ],
+    "The Slave Pens": [
+      {
+        "act": 5,
+        "level": 41,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Overseer Krow"
+          }
+        ]
+      }
+    ],
+    "The Control Blocks": [
+      {
+        "act": 5,
+        "level": 41,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Justicar Casticus"
+          }
+        ]
+      },
+      {
+        "act": 10,
+        "level": 66,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Vilenta"
+          }
+        ]
+      }
+    ],
+    "Oriath Square": [
+      {
+        "act": 5,
+        "level": 42,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "The Matriarch"
+          },
+          {
+            "name": "Oriath Enforcer"
+          }
+        ]
+      }
+    ],
+    "The Ruined Square": [
+      {
+        "act": 5,
+        "level": 44,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Utula, Stone and Steel"
+          },
+          {
+            "name": "The Risen Matriarch"
+          }
+        ]
+      }
+    ],
+    "The Templar Courts": [
+      {
+        "act": 5,
+        "level": 42,
+        "town": false,
+        "waypoint": true,
+        "bosses": []
+      }
+    ],
+    "The Torched Courts": [
+      {
+        "act": 5,
+        "level": 44,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Cato, Scholar of Light"
+          }
+        ]
+      },
+      {
+        "act": 10,
+        "level": 65,
+        "town": false,
+        "waypoint": false,
+        "bosses": []
+      }
+    ],
+    "The Chamber of Innocence": [
+      {
+        "act": 5,
+        "level": 43,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "High Templar Avarius"
+          }
+        ]
+      }
+    ],
+    "The Ossuary": [
+      {
+        "act": 5,
+        "level": 44,
+        "town": false,
+        "waypoint": false,
+        "bosses": []
+      },
+      {
+        "act": 10,
+        "level": 67,
+        "town": false,
+        "waypoint": false,
+        "bosses": []
+      }
+    ],
+    "The Reliquary": [
+      {
+        "act": 5,
+        "level": 44,
+        "town": false,
+        "waypoint": true,
+        "bosses": []
+      },
+      {
+        "act": 10,
+        "level": 67,
+        "town": false,
+        "waypoint": true,
+        "bosses": []
+      }
+    ],
+    "The Cathedral Rooftop": [
+      {
+        "act": 5,
+        "level": 45,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Kitava, the Insatiable"
+          }
+        ]
+      },
+      {
+        "act": 10,
+        "level": 64,
+        "town": false,
+        "waypoint": false,
+        "bosses": []
+      }
+    ],
+    "The Karui Fortress": [
+      {
+        "act": 6,
+        "level": 46,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Tukohama, Karui God of War"
+          }
+        ]
+      }
+    ],
+    "The Ridge": [
+      {
+        "act": 6,
+        "level": 46,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Fleetfreak"
+          }
+        ]
+      }
+    ],
+    "Shavronne's Tower": [
+      {
+        "act": 6,
+        "level": 47,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Shavronne the Returned"
+          },
+          {
+            "name": "Reassembled Brutus"
+          }
+        ]
+      }
+    ],
+    "The Beacon": [
+      {
+        "act": 6,
+        "level": 49,
+        "town": false,
+        "waypoint": true,
+        "bosses": []
+      }
+    ],
+    "The Brine King's Reef": [
+      {
+        "act": 6,
+        "level": 50,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Tsoagoth, The Brine King"
+          }
+        ]
+      }
+    ],
+    "The Bridge Encampment": [
+      {
+        "act": 7,
+        "level": 55,
+        "town": true,
+        "waypoint": true,
+        "bosses": []
+      }
+    ],
+    "The Crypt": [
+      {
+        "act": 7,
+        "level": 51,
+        "town": false,
+        "waypoint": true,
+        "bosses": []
+      }
+    ],
+    "Maligaro's Sanctum": [
+      {
+        "act": 7,
+        "level": 52,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Maligaro, the Artist"
+          },
+          {
+            "name": "Black Death, Pain Unending"
+          },
+          {
+            "name": "Fidelitas, Loyalty Undying"
+          }
+        ]
+      }
+    ],
+    "The Ashen Fields": [
+      {
+        "act": 7,
+        "level": 53,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Greust, Lord of the Forest"
+          },
+          {
+            "name": "Oak"
+          },
+          {
+            "name": "Alira"
+          },
+          {
+            "name": "Kraityn"
+          }
+        ]
+      }
+    ],
+    "The Causeway": [
+      {
+        "act": 7,
+        "level": 54,
+        "town": false,
+        "waypoint": true,
+        "bosses": []
+      }
+    ],
+    "The Vaal City": [
+      {
+        "act": 7,
+        "level": 54,
+        "town": false,
+        "waypoint": true,
+        "bosses": []
+      }
+    ],
+    "The Temple of Decay Level 1": [
+      {
+        "act": 7,
+        "level": 54,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Blightblade"
+          }
+        ]
+      }
+    ],
+    "The Temple of Decay Level 2": [
+      {
+        "act": 7,
+        "level": 55,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Arakaali, Spinner of Shadows"
+          }
+        ]
+      }
+    ],
+    "The Sarn Ramparts": [
+      {
+        "act": 8,
+        "level": 55,
+        "town": false,
+        "waypoint": true,
+        "bosses": []
+      }
+    ],
+    "The Toxic Conduits": [
+      {
+        "act": 8,
+        "level": 56,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Lingering Aberration"
+          }
+        ]
+      }
+    ],
+    "Doedre's Cesspool": [
+      {
+        "act": 8,
+        "level": 56,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Doedre the Vile"
+          }
+        ]
+      }
+    ],
+    "The Grand Promenade": [
+      {
+        "act": 8,
+        "level": 56,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Ondar, the Betrayer"
+          }
+        ]
+      }
+    ],
+    "The High Gardens": [
+      {
+        "act": 8,
+        "level": 58,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Yugul, Reflection of Terror"
+          }
+        ]
+      }
+    ],
+    "The Bath House": [
+      {
+        "act": 8,
+        "level": 57,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Hector Titucius, Eternal Servant"
+          }
+        ]
+      }
+    ],
+    "The Lunaris Concourse": [
+      {
+        "act": 8,
+        "level": 58,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Nightbringer Lucius"
+          }
+        ]
+      }
+    ],
+    "The Quay": [
+      {
+        "act": 8,
+        "level": 57,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Tolman"
+          }
+        ]
+      }
+    ],
+    "The Grain Gate": [
+      {
+        "act": 8,
+        "level": 57,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Gemling Legionnaire"
+          },
+          {
+            "name": "Gemling Captain"
+          }
+        ]
+      }
+    ],
+    "The Imperial Fields": [
+      {
+        "act": 8,
+        "level": 58,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Effigy of Fear"
+          }
+        ]
+      }
+    ],
+    "The Solaris Concourse": [
+      {
+        "act": 8,
+        "level": 58,
+        "town": false,
+        "waypoint": true,
+        "bosses": []
+      }
+    ],
+    "The Harbour Bridge": [
+      {
+        "act": 8,
+        "level": 60,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Lunaris, Eternal Moon"
+          },
+          {
+            "name": "Solaris, Eternal Sun"
+          }
+        ]
+      }
+    ],
+    "The Blood Aqueduct": [
+      {
+        "act": 9,
+        "level": 61,
+        "town": false,
+        "waypoint": true,
+        "bosses": []
+      }
+    ],
+    "The Descent": [
+      {
+        "act": 9,
+        "level": 61,
+        "town": false,
+        "waypoint": false,
+        "bosses": []
+      }
+    ],
+    "The Vastiri Desert": [
+      {
+        "act": 9,
+        "level": 61,
+        "town": false,
+        "waypoint": true,
+        "bosses": []
+      }
+    ],
+    "The Oasis": [
+      {
+        "act": 9,
+        "level": 61,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Shakari, Queen of the Sands"
+          }
+        ]
+      }
+    ],
+    "The Foothills": [
+      {
+        "act": 9,
+        "level": 62,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Boulderback"
+          }
+        ]
+      }
+    ],
+    "The Boiling Lake": [
+      {
+        "act": 9,
+        "level": 62,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "The Basilisk"
+          }
+        ]
+      }
+    ],
+    "The Tunnel": [
+      {
+        "act": 9,
+        "level": 62,
+        "town": false,
+        "waypoint": true,
+        "bosses": []
+      }
+    ],
+    "The Quarry": [
+      {
+        "act": 9,
+        "level": 63,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Garukhan, Queen of the Winds"
+          }
+        ]
+      }
+    ],
+    "The Refinery": [
+      {
+        "act": 9,
+        "level": 63,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "General Adus"
+          }
+        ]
+      }
+    ],
+    "The Belly of the Beast": [
+      {
+        "act": 9,
+        "level": 63,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Droolmaw"
+          }
+        ]
+      }
+    ],
+    "The Rotting Core": [
+      {
+        "act": 9,
+        "level": 64,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "The Depraved Trinity"
+          },
+          {
+            "name": "Doedre, Darksoul"
+          },
+          {
+            "name": "Maligaro, The Broken"
+          },
+          {
+            "name": "Shavronne, Unbound"
+          }
+        ]
+      }
+    ],
+    "Oriath Docks": [
+      {
+        "act": 10,
+        "level": 69,
+        "town": true,
+        "waypoint": true,
+        "bosses": []
+      }
+    ],
+    "The Ravaged Square": [
+      {
+        "act": 10,
+        "level": 64,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "The Rotten Matriarch"
+          }
+        ]
+      }
+    ],
+    "The Desecrated Chambers": [
+      {
+        "act": 10,
+        "level": 65,
+        "town": false,
+        "waypoint": true,
+        "bosses": [
+          {
+            "name": "Avarius, Reassembled"
+          }
+        ]
+      }
+    ],
+    "The Canals": [
+      {
+        "act": 10,
+        "level": 66,
+        "town": false,
+        "waypoint": false,
+        "bosses": []
+      }
+    ],
+    "The Feeding Trough": [
+      {
+        "act": 10,
+        "level": 67,
+        "town": false,
+        "waypoint": false,
+        "bosses": [
+          {
+            "name": "Kitava, the Insatiable"
+          }
+        ]
+      }
+    ],
+    "Oriath": [
+      {
+        "act": 11,
+        "level": 69,
+        "town": true,
+        "waypoint": true,
+        "bosses": []
+      }
+    ],
+    "The Templar Laboratory": [
+      {
+        "act": 11,
+        "level": 68,
+        "town": false,
+        "waypoint": true,
+        "bosses": []
+      }
+    ]
+  },
+  "vaal": {
+    "Strange Sinkhole": {
+      "bosses": [
+        [
+          "Mother of the Hive"
+        ]
+      ]
+    },
+    "Concealed Cavity": {
+      "bosses": [
+        [
+          "The All-seeing Eye"
+        ]
+      ]
+    },
+    "Sunken Shingle": {
+      "bosses": [
+        [
+          "Perquil the Lucky"
+        ]
+      ]
+    },
+    "Clouded Ridge": {
+      "bosses": [
+        [
+          "Konu, Maker of Wind"
+        ]
+      ]
+    },
+    "Forgotten Oubliette": {
+      "bosses": [
+        [
+          "Coniraya, Shadow of Malice"
+        ]
+      ]
+    },
+    "Remote Gulch": {
+      "bosses": [
+        [
+          "Sheaq, Maker of Floods"
+        ]
+      ]
+    },
+    "Narrow Ravine": {
+      "bosses": [
+        [
+          "Kamaq, Soilmaker"
+        ]
+      ]
+    },
+    "Mystical Clearing": {
+      "bosses": [
+        [
+          "Simi, the Nature Touched"
+        ]
+      ]
+    },
+    "Covered-up Hollow": {
+      "bosses": [
+        [
+          "Cintiq, the Inescapable"
+        ]
+      ]
+    },
+    "Hidden Patch": {
+      "bosses": [
+        [
+          "Thornrunner"
+        ]
+      ]
+    },
+    "Entombed Alcove": {
+      "bosses": [
+        [
+          "Shrapnelbearer"
+        ]
+      ]
+    },
+    "Secret Laboratory": {
+      "bosses": [
+        [
+          "Atziri's Pride"
+        ]
+      ]
+    },
+    "Secluded Copse": {
+      "bosses": [
+        [
+          "Kutec, Vaal Fleshsmith"
+        ]
+      ]
+    },
+    "Forbidden Chamber": {
+      "bosses": [
+        [
+          "Haviri, Vaal Metalsmith"
+        ]
+      ]
+    },
+    "Quarantined Quarters": {
+      "bosses": [
+        [
+          "The Sunburst Queen"
+        ]
+      ]
+    },
+    "Disused Furnace": {
+      "bosses": [
+        [
+          "Curator Miem"
+        ]
+      ]
+    },
+    "Blind Alley": {
+      "bosses": [
+        [
+          "M'gaska, the Living Pyre"
+        ]
+      ]
+    },
+    "Entombed Chamber": {
+      "bosses": [
+        [
+          "Ossecati, Boneshaper"
+        ]
+      ]
+    },
+    "Sacred Chambers": {
+      "bosses": [
+        [
+          "Shadow of Vengeance"
+        ]
+      ]
+    },
+    "Stagnant Canal": {
+      "bosses": [
+        [
+          "Wiraqucha, Ancient Guardian"
+        ]
+      ]
+    },
+    "Walled-off Ducts": {
+      "bosses": [
+        [
+          "Cava, Artist of Pain"
+        ]
+      ]
+    },
+    "Neglected Cellar": {
+      "bosses": [
+        [
+          "Rima, Deep Temptress"
+        ]
+      ]
+    },
+    "Arcane Chambers": {
+      "bosses": [
+        [
+          "Beheader Ataguchu"
+        ]
+      ]
+    },
+    "Inner Grounds": {
+      "bosses": [
+        [
+          "Inti of the Blood Moon"
+        ]
+      ]
+    },
+    "Sealed Corridors": {
+      "bosses": [
+        [
+          "Wiraq, the Impaler"
+        ]
+      ]
+    },
+    "Restricted Gallery": {
+      "bosses": [
+        [
+          "Ch'aska, Maker of Rain"
+        ]
+      ]
+    },
+    "Forgotten Conduit": {
+      "bosses": [
+        [
+          "Torrent of Fear"
+        ]
+      ]
+    },
+    "Ancient Catacomb": {
+      "bosses": [
+        [
+          "Commander of Flesh"
+        ]
+      ]
+    },
+    "Haunted Mineshaft": {
+      "bosses": [
+        [
+          "Calxipher"
+        ]
+      ]
+    },
+    "Abandoned Dam": {
+      "bosses": [
+        [
+          "Quetzerxi"
+        ]
+      ]
+    },
+    "Desolate Track": {
+      "bosses": [
+        [
+          "Quetzerxi"
+        ]
+      ]
+    },
+    "Reclaimed Barracks": {
+      "bosses": [
+        [
+          "Huitepa the Blind"
+        ]
+      ]
+    },
+    "Sealed Basement": {
+      "bosses": [
+        [
+          "Guraq, Daylight's Blade"
+        ]
+      ]
+    },
+    "Secluded Canal": {
+      "bosses": [
+        [
+          "Xuatl, Cutting Wind"
+        ]
+      ]
+    },
+    "Forbidden Archives": {
+      "bosses": [
+        [
+          "Exartze, the Woven Stone"
+        ]
+      ]
+    },
+    "Cremated Archives": {
+      "bosses": [
+        [
+          "Exartze, the Woven Stone"
+        ]
+      ]
+    },
+    "Twisted Inquisitorium": {
+      "bosses": [
+        [
+          "Anacuacotli, Death's Worship"
+        ]
+      ]
+    },
+    "Deathly Chambers": {
+      "bosses": [
+        [
+          "Harbinger of Disorder"
+        ]
+      ]
+    },
+    "Restricted Collection": {
+      "bosses": [
+        [
+          "Iorphia, Dream Eater"
+        ]
+      ]
+    },
+    "Side Chapel": {
+      "bosses": [
+        [
+          "Daluatti, Stoneraiser"
+        ]
+      ]
+    },
+    "Radiant Pools": {
+      "bosses": [
+        [
+          "Perquil the Lucky"
+        ]
+      ]
+    },
+    "Clouded Ledge": {
+      "bosses": [
+        [
+          "Simi, the Nature Touched"
+        ]
+      ]
+    },
+    "Sealed Repository": {
+      "bosses": [
+        [
+          "Inti of the Blood Moon"
+        ]
+      ]
+    },
+    "Flooded Complex": {
+      "bosses": [
+        [
+          "M'gaska, the Living Pyre"
+        ]
+      ]
+    },
+    "Forbidden Shrine": {
+      "bosses": [
+        [
+          "Shrapnelbearer"
+        ]
+      ]
+    },
+    "Evacuated Quarter": {
+      "bosses": [
+        [
+          "Curator Miem"
+        ]
+      ]
+    },
+    "Concealed Caldarium": {
+      "bosses": [
+        [
+          "Cava, Artist of Pain"
+        ]
+      ]
+    },
+    "Moonlit Chambers": {
+      "bosses": [
+        [
+          "Beheader Ataguchu"
+        ]
+      ]
+    },
+    "Shifting Sands": {
+      "bosses": [
+        [
+          "Wiraq, the Impaler"
+        ]
+      ]
+    },
+    "Forgotten Gulch": {
+      "bosses": [
+        [
+          "Curator Miem"
+        ]
+      ]
+    },
+    "Desolate Isle": {
+      "bosses": [
+        [
+          "Wiraqucha, Ancient Guardian"
+        ]
+      ]
+    },
+    "Dusty Bluff": {
+      "bosses": [
+        [
+          "Quetzerxi"
+        ]
+      ]
+    }
+  },
+  "labyrinth": {
+    "Aspirants' Plaza": {
+      "trial": false
+    },
+    "Trial of Piercing Truth": {
+      "trial": true
+    },
+    "Trial of Swirling Fear": {
+      "trial": true
+    },
+    "Trial of Crippling Grief": {
+      "trial": true
+    },
+    "Trial of Burning Rage": {
+      "trial": true
+    },
+    "Trial of Lingering Pain": {
+      "trial": true
+    },
+    "Trial of Stinging Doubt": {
+      "trial": true
+    }
+  }
 }

--- a/resource/areas.json
+++ b/resource/areas.json
@@ -2386,5 +2386,1567 @@
     "Trial of Stinging Doubt": {
       "trial": true
     }
+  },
+  "map": {
+    "Beach Map": [
+      {
+        "level": 68,
+        "tier": 1,
+        "bosses": [
+          "Glace"
+        ]
+      }
+    ],
+    "Dungeon Map": [
+      {
+        "level": 68,
+        "tier": 1,
+        "bosses": [
+          "Penitentiary Incarcerator"
+        ]
+      }
+    ],
+    "Graveyard Map": [
+      {
+        "level": 68,
+        "tier": 1,
+        "bosses": [
+          "Steelpoint the Avenger",
+          "Champion of Frost",
+          "Thunderskull"
+        ]
+      }
+    ],
+    "Lookout Map": [
+      {
+        "level": 68,
+        "tier": 1,
+        "bosses": [
+          "The Grey Plague"
+        ]
+      }
+    ],
+    "Alleyways Map": [
+      {
+        "level": 69,
+        "tier": 2,
+        "bosses": [
+          "Calderus"
+        ]
+      }
+    ],
+    "Arid Lake Map": [
+      {
+        "level": 69,
+        "tier": 2,
+        "bosses": [
+          "Drought-Maddened Rhoa"
+        ]
+      }
+    ],
+    "Desert Map": [
+      {
+        "level": 69,
+        "tier": 2,
+        "bosses": [
+          "Preethi, Eye-Pecker"
+        ]
+      }
+    ],
+    "Flooded Mine Map": [
+      {
+        "level": 69,
+        "tier": 2,
+        "bosses": [
+          "The Eroding One"
+        ]
+      }
+    ],
+    "Marshes Map": [
+      {
+        "level": 69,
+        "tier": 2,
+        "bosses": [
+          "Tore, Towering Ancient"
+        ]
+      }
+    ],
+    "Pen Map": [
+      {
+        "level": 69,
+        "tier": 2,
+        "bosses": [
+          "Arwyn, the Houndmaster"
+        ]
+      }
+    ],
+    "Arcade Map": [
+      {
+        "level": 70,
+        "tier": 3,
+        "bosses": [
+          "Herald of Ashes",
+          "Herald of Thunder"
+        ]
+      }
+    ],
+    "Burial Chambers Map": [
+      {
+        "level": 70,
+        "tier": 3,
+        "bosses": [
+          "Witch of the Cauldron"
+        ]
+      }
+    ],
+    "Cage Map": [
+      {
+        "level": 70,
+        "tier": 3,
+        "bosses": [
+          "Executioner Bloodwing"
+        ]
+      }
+    ],
+    "Cells Map": [
+      {
+        "level": 70,
+        "tier": 3,
+        "bosses": [
+          "Megaera"
+        ]
+      }
+    ],
+    "Excavation Map": [
+      {
+        "level": 70,
+        "tier": 3,
+        "bosses": [
+          "Shrieker Eihal",
+          "Breaker Toruul"
+        ]
+      }
+    ],
+    "Iceberg Map": [
+      {
+        "level": 70,
+        "tier": 3,
+        "bosses": [
+          "One random Mutewind Warband boss with a supporting Warband"
+        ]
+      }
+    ],
+    "Leyline Map": [
+      {
+        "level": 70,
+        "tier": 3,
+        "bosses": [
+          "Mirage of Bones"
+        ]
+      }
+    ],
+    "Peninsula Map": [
+      {
+        "level": 70,
+        "tier": 3,
+        "bosses": [
+          "Titan of the Grove"
+        ]
+      }
+    ],
+    "Port Map": [
+      {
+        "level": 70,
+        "tier": 3,
+        "bosses": [
+          "Unravelling Horror"
+        ]
+      }
+    ],
+    "Springs Map": [
+      {
+        "level": 70,
+        "tier": 3,
+        "bosses": [
+          "Aulen Greychain"
+        ]
+      }
+    ],
+    "Esh's Domain": [
+      {
+        "level": 70,
+        "tier": null,
+        "bosses": [
+          "Esh, Forked Thought"
+        ]
+      }
+    ],
+    "Tul's Domain": [
+      {
+        "level": 70,
+        "tier": null,
+        "bosses": [
+          "Tul, Creeping Avalanche"
+        ]
+      }
+    ],
+    "Xoph's Domain": [
+      {
+        "level": 70,
+        "tier": null,
+        "bosses": [
+          "Xoph, Dark Embers"
+        ]
+      }
+    ],
+    "The Apex of Sacrifice": [
+      {
+        "level": 70,
+        "tier": null,
+        "bosses": [
+          "Atziri, Queen of the Vaal",
+          "Q'ura",
+          "Y'ara'az",
+          "A'alai",
+          "Vessel of the Vaal",
+          "Vessel of the Vaal"
+        ]
+      }
+    ],
+    "Canyon Map": [
+      {
+        "level": 71,
+        "tier": 4,
+        "bosses": [
+          "Gnar, Eater of Carrion",
+          "Stonebeak, Battle Fowl"
+        ]
+      }
+    ],
+    "Chateau Map": [
+      {
+        "level": 71,
+        "tier": 4,
+        "bosses": [
+          "The Reaver"
+        ]
+      }
+    ],
+    "City Square Map": [
+      {
+        "level": 71,
+        "tier": 4,
+        "bosses": [
+          "Carius, the Unnatural",
+          "Pileah, Corpse Burner",
+          "Pileah, Burning Corpse"
+        ]
+      }
+    ],
+    "Courthouse Map": [
+      {
+        "level": 71,
+        "tier": 4,
+        "bosses": [
+          "Thena Moga, The Crimson Storm",
+          "Ion Darkshroud, The Hungering Blade",
+          "Bolt Brownfur, Earth Churner"
+        ]
+      }
+    ],
+    "Gorge Map": [
+      {
+        "level": 71,
+        "tier": 4,
+        "bosses": [
+          "Rek'tar, the Breaker"
+        ]
+      }
+    ],
+    "Grotto Map": [
+      {
+        "level": 71,
+        "tier": 4,
+        "bosses": [
+          "Void Anomaly"
+        ]
+      }
+    ],
+    "Lighthouse Map": [
+      {
+        "level": 71,
+        "tier": 4,
+        "bosses": [
+          "One random Redblade Warband boss with a supporting Warband"
+        ]
+      }
+    ],
+    "Relic Chambers Map": [
+      {
+        "level": 71,
+        "tier": 4,
+        "bosses": [
+          "Litanius, the Black Prayer"
+        ]
+      }
+    ],
+    "Strand Map": [
+      {
+        "level": 71,
+        "tier": 4,
+        "bosses": [
+          "Master of the Blade Massier"
+        ]
+      }
+    ],
+    "Whakawairua Tuahu": [
+      {
+        "level": 71,
+        "tier": 4,
+        "bosses": [
+          "Tormented Temptress"
+        ]
+      }
+    ],
+    "Volcano Map": [
+      {
+        "level": 71,
+        "tier": 4,
+        "bosses": [
+          "Forest of Flames"
+        ]
+      }
+    ],
+    "Ancient City Map": [
+      {
+        "level": 72,
+        "tier": 5,
+        "bosses": [
+          "Lady Stormflay"
+        ]
+      }
+    ],
+    "Barrows Map": [
+      {
+        "level": 72,
+        "tier": 5,
+        "bosses": [
+          "Beast of the Pits"
+        ]
+      }
+    ],
+    "Channel Map": [
+      {
+        "level": 72,
+        "tier": 5,
+        "bosses": [
+          "The Winged Death"
+        ]
+      }
+    ],
+    "Conservatory Map": [
+      {
+        "level": 72,
+        "tier": 5,
+        "bosses": [
+          "The Forgotten Soldier"
+        ]
+      }
+    ],
+    "Haunted Mansion Map": [
+      {
+        "level": 72,
+        "tier": 5,
+        "bosses": [
+          "Barthol, the Pure",
+          "Barthol, the Corrupter"
+        ]
+      }
+    ],
+    "Ivory Temple Map": [
+      {
+        "level": 72,
+        "tier": 5,
+        "bosses": [
+          "One random Perandus Manor boss"
+        ]
+      }
+    ],
+    "Maze Map": [
+      {
+        "level": 72,
+        "tier": 5,
+        "bosses": [
+          "Shadow of the Vaal"
+        ]
+      }
+    ],
+    "Spider Lair Map": [
+      {
+        "level": 72,
+        "tier": 5,
+        "bosses": [
+          "Thraxia"
+        ]
+      }
+    ],
+    "Sulphur Vents Map": [
+      {
+        "level": 72,
+        "tier": 5,
+        "bosses": [
+          "The Gorgon"
+        ]
+      }
+    ],
+    "Toxic Sewer Map": [
+      {
+        "level": 72,
+        "tier": 5,
+        "bosses": [
+          "Arachnoxia"
+        ]
+      }
+    ],
+    "The Beachhead": [
+      {
+        "level": 72,
+        "tier": 5,
+        "bosses": []
+      }
+    ],
+    "Academy Map": [
+      {
+        "level": 73,
+        "tier": 6,
+        "bosses": [
+          "The Arbiter of Knowledge"
+        ]
+      }
+    ],
+    "Atoll Map": [
+      {
+        "level": 73,
+        "tier": 6,
+        "bosses": [
+          "Puruna, the Challenger"
+        ]
+      }
+    ],
+    "Maelström of Chaos": [
+      {
+        "level": 73,
+        "tier": 6,
+        "bosses": [
+          "Merveil, the Reflection",
+          "Merveil, the Returned"
+        ]
+      }
+    ],
+    "Ashen Wood Map": [
+      {
+        "level": 73,
+        "tier": 6,
+        "bosses": [
+          "Lord of the Ashen Arrow"
+        ]
+      }
+    ],
+    "Cemetery Map": [
+      {
+        "level": 73,
+        "tier": 6,
+        "bosses": [
+          "Erebix, Light's Bane"
+        ]
+      }
+    ],
+    "Hallowed Ground": [
+      {
+        "level": 73,
+        "tier": 6,
+        "bosses": [
+          "Maker of Mires"
+        ]
+      }
+    ],
+    "Fields Map": [
+      {
+        "level": 73,
+        "tier": 6,
+        "bosses": [
+          "Drek, Apex Hunter"
+        ]
+      }
+    ],
+    "Jungle Valley Map": [
+      {
+        "level": 73,
+        "tier": 6,
+        "bosses": [
+          "Queen of the Great Tangle"
+        ]
+      }
+    ],
+    "Mausoleum Map": [
+      {
+        "level": 73,
+        "tier": 6,
+        "bosses": [
+          "Tolman, the Exhumer"
+        ]
+      }
+    ],
+    "Phantasmagoria Map": [
+      {
+        "level": 73,
+        "tier": 6,
+        "bosses": [
+          "Erythrophagia"
+        ]
+      }
+    ],
+    "Thicket Map": [
+      {
+        "level": 73,
+        "tier": 6,
+        "bosses": [
+          "The Primal One"
+        ]
+      }
+    ],
+    "Underground Sea Map": [
+      {
+        "level": 73,
+        "tier": 6,
+        "bosses": [
+          "Merveil, the Reflection"
+        ]
+      }
+    ],
+    "Wharf Map": [
+      {
+        "level": 73,
+        "tier": 6,
+        "bosses": [
+          "Stone of the Currents"
+        ]
+      }
+    ],
+    "Arachnid Nest Map": [
+      {
+        "level": 74,
+        "tier": 7,
+        "bosses": [
+          "Spinner of False Hope"
+        ]
+      }
+    ],
+    "Bazaar Map": [
+      {
+        "level": 74,
+        "tier": 7,
+        "bosses": [
+          "Ancient Sculptor"
+        ]
+      }
+    ],
+    "Bone Crypt Map": [
+      {
+        "level": 74,
+        "tier": 7,
+        "bosses": [
+          "Xixic, High Necromancer"
+        ]
+      }
+    ],
+    "Olmec's Sanctum": [
+      {
+        "level": 74,
+        "tier": 7,
+        "bosses": [
+          "Olmec, the All Stone"
+        ]
+      }
+    ],
+    "Coral Ruins Map": [
+      {
+        "level": 74,
+        "tier": 7,
+        "bosses": [
+          "Captain Tanner Lightfoot"
+        ]
+      }
+    ],
+    "Dunes Map": [
+      {
+        "level": 74,
+        "tier": 7,
+        "bosses": [
+          "The Blacksmith"
+        ]
+      }
+    ],
+    "Pillars of Arun": [
+      {
+        "level": 74,
+        "tier": 7,
+        "bosses": [
+          "Talin, Faithbreaker"
+        ]
+      }
+    ],
+    "Gardens Map": [
+      {
+        "level": 74,
+        "tier": 7,
+        "bosses": [
+          "Sallazzang"
+        ]
+      }
+    ],
+    "Lava Chamber Map": [
+      {
+        "level": 74,
+        "tier": 7,
+        "bosses": [
+          "Fire and Fury"
+        ]
+      }
+    ],
+    "Ramparts Map": [
+      {
+        "level": 74,
+        "tier": 7,
+        "bosses": [
+          "Legius Garhall"
+        ]
+      }
+    ],
+    "Residence Map": [
+      {
+        "level": 74,
+        "tier": 7,
+        "bosses": [
+          "Excellis Aurafix"
+        ]
+      }
+    ],
+    "Tribunal Map": [
+      {
+        "level": 74,
+        "tier": 7,
+        "bosses": [
+          "Shavronne the Sickening"
+        ]
+      }
+    ],
+    "Underground River Map": [
+      {
+        "level": 74,
+        "tier": 7,
+        "bosses": [
+          "It That Fell"
+        ]
+      }
+    ],
+    "Caer Blaidd, Wolfpack's Den": [
+      {
+        "level": 74,
+        "tier": 7,
+        "bosses": [
+          "Solus, Pack Alpha",
+          "Storm Eye",
+          "Winterfang"
+        ]
+      }
+    ],
+    "Armoury Map": [
+      {
+        "level": 75,
+        "tier": 8,
+        "bosses": [
+          "Warmonger"
+        ]
+      }
+    ],
+    "Courtyard Map": [
+      {
+        "level": 75,
+        "tier": 8,
+        "bosses": [
+          "Oriath's Vengeance",
+          "Oriath's Vigil",
+          "Oriath's Virtue"
+        ]
+      }
+    ],
+    "The Vinktar Square": [
+      {
+        "level": 75,
+        "tier": 8,
+        "bosses": [
+          "Avatar of Thunder"
+        ]
+      }
+    ],
+    "Geode Map": [
+      {
+        "level": 75,
+        "tier": 8,
+        "bosses": [
+          "Avatar of Undoing"
+        ]
+      }
+    ],
+    "Infested Valley Map": [
+      {
+        "level": 75,
+        "tier": 8,
+        "bosses": [
+          "Gorulis, Will-Thief"
+        ]
+      }
+    ],
+    "Laboratory Map": [
+      {
+        "level": 75,
+        "tier": 8,
+        "bosses": [
+          "Riftwalker"
+        ]
+      }
+    ],
+    "Mineral Pools Map": [
+      {
+        "level": 75,
+        "tier": 8,
+        "bosses": [
+          "Merveil, the Reflection",
+          "Merveil, the Returned"
+        ]
+      }
+    ],
+    "Mud Geyser Map": [
+      {
+        "level": 75,
+        "tier": 8,
+        "bosses": [
+          "Tunneltrap"
+        ]
+      }
+    ],
+    "Overgrown Ruin Map": [
+      {
+        "level": 75,
+        "tier": 8,
+        "bosses": [
+          "Visceris"
+        ]
+      }
+    ],
+    "Shore Map": [
+      {
+        "level": 75,
+        "tier": 8,
+        "bosses": [
+          "Belcer, the Pirate Lord"
+        ]
+      }
+    ],
+    "Mao Kun": [
+      {
+        "level": 75,
+        "tier": 8,
+        "bosses": [
+          "Fairgraves, Never Dying"
+        ]
+      }
+    ],
+    "The Pale Court": [
+      {
+        "level": 75,
+        "tier": null,
+        "bosses": [
+          "Eber, the Plaguemaw",
+          "Inya, the Unbearable Whispers",
+          "Volkuur, the Unbreathing Queen",
+          "Yriel, the Feral Lord"
+        ]
+      }
+    ],
+    "Tropical Island Map": [
+      {
+        "level": 75,
+        "tier": 8,
+        "bosses": [
+          "Blood Progenitor"
+        ]
+      }
+    ],
+    "Uul-Netol's Domain": [
+      {
+        "level": 75,
+        "tier": null,
+        "bosses": [
+          "Uul-Netol, Unburdened Flesh"
+        ]
+      }
+    ],
+    "Untainted Paradise": [
+      {
+        "level": 75,
+        "tier": 8,
+        "bosses": [
+          "Clutch Queen",
+          "Colossal Spitter",
+          "Elder Devourer",
+          "Great Maw",
+          "Prime Ape",
+          "The First Rhoa"
+        ]
+      }
+    ],
+    "Vaal Pyramid Map": [
+      {
+        "level": 75,
+        "tier": 8,
+        "bosses": [
+          "The Fallen Queen",
+          "The Hollow Lady",
+          "The Broken Prince"
+        ]
+      }
+    ],
+    "Vaults of Atziri": [
+      {
+        "level": 75,
+        "tier": 8,
+        "bosses": [
+          "(none)"
+        ]
+      }
+    ],
+    "Arena Map": [
+      {
+        "level": 76,
+        "tier": 9,
+        "bosses": [
+          "Avatar of the Forge",
+          "Avatar of the Huntress",
+          "Avatar of the Skies"
+        ]
+      }
+    ],
+    "Estuary Map": [
+      {
+        "level": 76,
+        "tier": 9,
+        "bosses": [
+          "Sumter the Twisted"
+        ]
+      }
+    ],
+    "Moon Temple Map": [
+      {
+        "level": 76,
+        "tier": 9,
+        "bosses": [
+          "Sebbert, Crescent's Point"
+        ]
+      }
+    ],
+    "The Twilight Temple": [
+      {
+        "level": 76,
+        "tier": 9,
+        "bosses": [
+          "Helial, the Day Unending",
+          "Selenia, the Endless Night"
+        ]
+      }
+    ],
+    "Museum Map": [
+      {
+        "level": 76,
+        "tier": 9,
+        "bosses": [
+          "He of Many Pieces"
+        ]
+      }
+    ],
+    "The Putrid Cloister": [
+      {
+        "level": 76,
+        "tier": 9,
+        "bosses": [
+          "Headmistress Braeta"
+        ]
+      }
+    ],
+    "Plateau Map": [
+      {
+        "level": 76,
+        "tier": 9,
+        "bosses": [
+          "Puruna, the Challenger",
+          "Poporo, the Highest Spire"
+        ]
+      }
+    ],
+    "Scriptorium Map": [
+      {
+        "level": 76,
+        "tier": 9,
+        "bosses": [
+          "Gisale, Thought Thief"
+        ]
+      }
+    ],
+    "Sepulchre Map": [
+      {
+        "level": 76,
+        "tier": 9,
+        "bosses": [
+          "Doedre the Defiler"
+        ]
+      }
+    ],
+    "Temple Map": [
+      {
+        "level": 76,
+        "tier": 9,
+        "bosses": [
+          "Jorus, Sky's Edge"
+        ]
+      }
+    ],
+    "Poorjoy's Asylum": [
+      {
+        "level": 76,
+        "tier": 9,
+        "bosses": [
+          "Mistress Hyseria"
+        ]
+      }
+    ],
+    "Tower Map": [
+      {
+        "level": 76,
+        "tier": 9,
+        "bosses": [
+          "Liantra Bazur"
+        ]
+      }
+    ],
+    "Vault Map": [
+      {
+        "level": 76,
+        "tier": 9,
+        "bosses": [
+          "Guardian of the Vault"
+        ]
+      }
+    ],
+    "Waste Pool Map": [
+      {
+        "level": 76,
+        "tier": 9,
+        "bosses": [
+          "Portentia, the Foul"
+        ]
+      }
+    ],
+    "Arachnid Tomb Map": [
+      {
+        "level": 77,
+        "tier": 10,
+        "bosses": [
+          "Hybrid Widow"
+        ]
+      }
+    ],
+    "Belfry Map": [
+      {
+        "level": 77,
+        "tier": 10,
+        "bosses": [
+          "Lord of the Grey"
+        ]
+      }
+    ],
+    "Bog Map": [
+      {
+        "level": 77,
+        "tier": 10,
+        "bosses": [
+          "Skullbeak"
+        ]
+      }
+    ],
+    "Cursed Crypt Map": [
+      {
+        "level": 77,
+        "tier": 10,
+        "bosses": [
+          "Pagan Bishop of Agony"
+        ]
+      }
+    ],
+    "The Coward's Trial": [
+      {
+        "level": 77,
+        "tier": 10,
+        "bosses": [
+          "Infector of Dreams"
+        ]
+      }
+    ],
+    "Orchard Map": [
+      {
+        "level": 77,
+        "tier": 10,
+        "bosses": [
+          "Vision of Justice"
+        ]
+      }
+    ],
+    "Pier Map": [
+      {
+        "level": 77,
+        "tier": 10,
+        "bosses": [
+          "Ancient Architect"
+        ]
+      }
+    ],
+    "Precinct Map": [
+      {
+        "level": 77,
+        "tier": 10,
+        "bosses": [
+          "Three random Rogue Exiles"
+        ]
+      }
+    ],
+    "Shipyard Map": [
+      {
+        "level": 77,
+        "tier": 10,
+        "bosses": [
+          "One random Brinerot Warband boss with a supporting Warband"
+        ]
+      }
+    ],
+    "Siege Map": [
+      {
+        "level": 77,
+        "tier": 10,
+        "bosses": [
+          "Tahsin, Warmaker"
+        ]
+      }
+    ],
+    "The Beachhead 10": [
+      {
+        "level": 77,
+        "tier": 10,
+        "bosses": [
+          ""
+        ]
+      }
+    ],
+    "Wasteland Map": [
+      {
+        "level": 77,
+        "tier": 10,
+        "bosses": [
+          "The Brittle Emperor"
+        ]
+      }
+    ],
+    "Colonnade Map": [
+      {
+        "level": 78,
+        "tier": 11,
+        "bosses": [
+          "Tyrant"
+        ]
+      }
+    ],
+    "Coves Map": [
+      {
+        "level": 78,
+        "tier": 11,
+        "bosses": [
+          "Telvar, the Inebriated Pirate Treasure"
+        ]
+      }
+    ],
+    "Factory Map": [
+      {
+        "level": 78,
+        "tier": 11,
+        "bosses": [
+          "Pesquin, the Mad Baron"
+        ]
+      }
+    ],
+    "Mesa Map": [
+      {
+        "level": 78,
+        "tier": 11,
+        "bosses": [
+          "Oak the Mighty"
+        ]
+      }
+    ],
+    "Lair Map": [
+      {
+        "level": 78,
+        "tier": 11,
+        "bosses": [
+          "Lycius, Midnight's Howl"
+        ]
+      }
+    ],
+    "Pit Map": [
+      {
+        "level": 78,
+        "tier": 11,
+        "bosses": [
+          "Olof, Son of the Headsman"
+        ]
+      }
+    ],
+    "Primordial Pool Map": [
+      {
+        "level": 78,
+        "tier": 11,
+        "bosses": [
+          "Nightmare's Omen"
+        ]
+      }
+    ],
+    "Promenade Map": [
+      {
+        "level": 78,
+        "tier": 11,
+        "bosses": [
+          "Blackguard Avenger Blackguard Tempest"
+        ]
+      }
+    ],
+    "Hall of Grandmasters": [
+      {
+        "level": 78,
+        "tier": 11,
+        "bosses": [
+          "(none)*"
+        ]
+      }
+    ],
+    "Spider Forest Map": [
+      {
+        "level": 78,
+        "tier": 11,
+        "bosses": [
+          "Enticer of Rot"
+        ]
+      }
+    ],
+    "Waterways Map": [
+      {
+        "level": 78,
+        "tier": 11,
+        "bosses": [
+          "Fragment of Winter"
+        ]
+      }
+    ],
+    "Castle Ruins Map": [
+      {
+        "level": 79,
+        "tier": 12,
+        "bosses": [
+          "Leif, the Swift-Handed"
+        ]
+      }
+    ],
+    "Crystal Ore Map": [
+      {
+        "level": 79,
+        "tier": 12,
+        "bosses": [
+          "Champion of the Hollows Lord of the Hollows Messenger of the Hollows"
+        ]
+      }
+    ],
+    "Defiled Cathedral Map": [
+      {
+        "level": 79,
+        "tier": 12,
+        "bosses": [
+          "Woad, Mockery of Man"
+        ]
+      }
+    ],
+    "Necropolis Map": [
+      {
+        "level": 79,
+        "tier": 12,
+        "bosses": [
+          "Burtok, Conjuror of Bones"
+        ]
+      }
+    ],
+    "Death and Taxes": [
+      {
+        "level": 79,
+        "tier": 12,
+        "bosses": [
+          "Avatar of Apocalypse"
+        ]
+      }
+    ],
+    "Overgrown Shrine Map": [
+      {
+        "level": 79,
+        "tier": 12,
+        "bosses": [
+          "Maligaro the Mutilator"
+        ]
+      }
+    ],
+    "Acton's Nightmare": [
+      {
+        "level": 79,
+        "tier": 12,
+        "bosses": [
+          "Rose Thorn"
+        ]
+      }
+    ],
+    "Racecourse Map": [
+      {
+        "level": 79,
+        "tier": 12,
+        "bosses": [
+          "Shredder of Gladiators Crusher of Gladiators Bringer of Blood"
+        ]
+      }
+    ],
+    "Summit Map": [
+      {
+        "level": 79,
+        "tier": 12,
+        "bosses": [
+          "Mephod, the Earth Scorcher"
+        ]
+      }
+    ],
+    "Torture Chamber Map": [
+      {
+        "level": 79,
+        "tier": 12,
+        "bosses": [
+          "Shock and Horror"
+        ]
+      }
+    ],
+    "Oba's Cursed Trove": [
+      {
+        "level": 79,
+        "tier": 12,
+        "bosses": []
+      }
+    ],
+    "Villa Map": [
+      {
+        "level": 79,
+        "tier": 12,
+        "bosses": [
+          "The High Templar"
+        ]
+      }
+    ],
+    "Arsenal Map": [
+      {
+        "level": 80,
+        "tier": 13,
+        "bosses": [
+          "The Steel Soul"
+        ]
+      }
+    ],
+    "Caldera Map": [
+      {
+        "level": 80,
+        "tier": 13,
+        "bosses": [
+          "The Infernal King"
+        ]
+      }
+    ],
+    "Core Map": [
+      {
+        "level": 80,
+        "tier": 13,
+        "bosses": [
+          "Eater of Souls"
+        ]
+      }
+    ],
+    "Chayula's Domain": [
+      {
+        "level": 80,
+        "tier": null,
+        "bosses": [
+          "Chayula, Who Dreamt"
+        ]
+      }
+    ],
+    "Desert Spring Map": [
+      {
+        "level": 80,
+        "tier": 13,
+        "bosses": [
+          "Terror of the Infinite Drifts"
+        ]
+      }
+    ],
+    "Ghetto Map": [
+      {
+        "level": 80,
+        "tier": 13,
+        "bosses": [
+          "Hephaeus, The Hammer"
+        ]
+      }
+    ],
+    "Malformation Map": [
+      {
+        "level": 80,
+        "tier": 13,
+        "bosses": [
+          "Nightmare Manifest"
+        ]
+      }
+    ],
+    "Park Map": [
+      {
+        "level": 80,
+        "tier": 13,
+        "bosses": [
+          "Suncaller Asha"
+        ]
+      }
+    ],
+    "Shrine Map": [
+      {
+        "level": 80,
+        "tier": 13,
+        "bosses": [
+          "Piety the Empyrean"
+        ]
+      }
+    ],
+    "Terrace Map": [
+      {
+        "level": 80,
+        "tier": 13,
+        "bosses": [
+          "Varhesh, Shimmering Aberration"
+        ]
+      }
+    ],
+    "The Alluring Abyss": [
+      {
+        "level": 80,
+        "tier": null,
+        "bosses": [
+          "Atziri, Queen of the Vaal",
+          "Q'ura",
+          "Y'ara'az",
+          "A'alai",
+          "Vessel of the Vaal",
+          "Vessel of the Vaal"
+        ]
+      }
+    ],
+    "Acid Lakes Map": [
+      {
+        "level": 81,
+        "tier": 14,
+        "bosses": [
+          "Two random Renegades Warband bosses with a supporting Warband"
+        ]
+      }
+    ],
+    "Colosseum Map": [
+      {
+        "level": 81,
+        "tier": 14,
+        "bosses": [
+          "Ambrius, Legion Slayer"
+        ]
+      }
+    ],
+    "Crimson Temple Map": [
+      {
+        "level": 81,
+        "tier": 14,
+        "bosses": [
+          "The Sanguine Siren"
+        ]
+      }
+    ],
+    "Dark Forest Map": [
+      {
+        "level": 81,
+        "tier": 14,
+        "bosses": [
+          "The Cursed King"
+        ]
+      }
+    ],
+    "Dig Map": [
+      {
+        "level": 81,
+        "tier": 14,
+        "bosses": [
+          "Stalker of the Endless Dunes"
+        ]
+      }
+    ],
+    "Palace Map": [
+      {
+        "level": 81,
+        "tier": 14,
+        "bosses": [
+          "God's Chosen The Hallowed Husk"
+        ]
+      }
+    ],
+    "Plaza Map": [
+      {
+        "level": 81,
+        "tier": 14,
+        "bosses": [
+          "The Goddess"
+        ]
+      }
+    ],
+    "Basilica Map": [
+      {
+        "level": 82,
+        "tier": 15,
+        "bosses": [
+          "Konley, the Unrepentant",
+          "The Cleansing Light"
+        ]
+      }
+    ],
+    "Carcass Map": [
+      {
+        "level": 82,
+        "tier": 15,
+        "bosses": [
+          "Amalgam of Nightmares"
+        ]
+      }
+    ],
+    "Lava Lake Map": [
+      {
+        "level": 82,
+        "tier": 15,
+        "bosses": [
+          "Kitava, the Insatiable"
+        ]
+      }
+    ],
+    "Reef Map": [
+      {
+        "level": 82,
+        "tier": 15,
+        "bosses": [
+          "Nassar, Lion of the Seas"
+        ]
+      }
+    ],
+    "Sunken City Map": [
+      {
+        "level": 82,
+        "tier": 15,
+        "bosses": [
+          "Armala, the Widow"
+        ]
+      }
+    ],
+    "The Beachhead 15": [
+      {
+        "level": 82,
+        "tier": 15,
+        "bosses": [
+          ""
+        ]
+      }
+    ],
+    "Forge of the Phoenix Map": [
+      {
+        "level": 83,
+        "tier": 16,
+        "bosses": [
+          "Guardian of the Phoenix"
+        ]
+      }
+    ],
+    "Lair of the Hydra Map": [
+      {
+        "level": 83,
+        "tier": 16,
+        "bosses": [
+          "Guardian of the Hydra"
+        ]
+      }
+    ],
+    "Maze of the Minotaur Map": [
+      {
+        "level": 83,
+        "tier": 16,
+        "bosses": [
+          "Guardian of the Minotaur"
+        ]
+      }
+    ],
+    "Pit of the Chimera Map": [
+      {
+        "level": 83,
+        "tier": 16,
+        "bosses": [
+          "Guardian of the Chimera"
+        ]
+      }
+    ],
+    "Vaal Temple Map": [
+      {
+        "level": 83,
+        "tier": 16,
+        "bosses": [
+          "K'aj A'alai",
+          "K'aj Q'ura",
+          "K'aj Y'ara'az"
+        ]
+      }
+    ],
+    "The Shaper's Realm": [
+      {
+        "level": 84,
+        "tier": null,
+        "bosses": [
+          "The Shaper"
+        ]
+      }
+    ]
   }
 }

--- a/resource/events.json
+++ b/resource/events.json
@@ -1,104 +1,110 @@
 {
-  "area":{
-    "regex":"\\[INFO Client [0-9]*] : You have entered (.*)\\.",
-    "function":"evalArea"
+  "instanceServer": {
+    "regex": "\\[INFO Client [0-9]*] Connecting to instance server at (.*)",
+    "properties": {
+      "address": 1
+    }
   },
-  "areaJoin":{
-    "regex":"\\[INFO Client [0-9]*] : (\\S+) has joined the area\\.",
-    "properties":{
-      "player":{
-        "name":1
+  "area": {
+    "regex": "\\[INFO Client [0-9]*] : You have entered (.*)\\.",
+    "function": "evalArea"
+  },
+  "areaJoin": {
+    "regex": "\\[INFO Client [0-9]*] : (\\S+) has joined the area\\.",
+    "properties": {
+      "player": {
+        "name": 1
       }
     }
   },
-  "areaLeave":{
-    "regex":"\\[INFO Client [0-9]*] : (\\S+) has left the area\\.",
-    "properties":{
-      "player":{
-        "name":1
+  "areaLeave": {
+    "regex": "\\[INFO Client [0-9]*] : (\\S+) has left the area\\.",
+    "properties": {
+      "player": {
+        "name": 1
       }
     }
   },
-  "message":{
-    "regex":"\\[INFO Client [0-9]*] (#|\\$|%|&|)(?:<(.+)> )?((?!Enumerated )[a-zA-Z_, ]+): (.+)",
-    "function":"evalMessage"
+  "message": {
+    "regex": "\\[INFO Client [0-9]*] (#|\\$|%|&|)(?:<(.+)> )?((?!Enumerated )[a-zA-Z_, ]+): (.+)",
+    "function": "evalMessage"
   },
-  "whisper":{
-    "regex":"\\[INFO Client [0-9]*] @(To|From) (?:<(.+)> )?([a-zA-Z_, ]+): (.+)",
-    "properties":{
-      "direction":1,
-      "player":{
-        "guild":2,
-        "name":3
+  "whisper": {
+    "regex": "\\[INFO Client [0-9]*] @(To|From) (?:<(.+)> )?([a-zA-Z_, ]+): (.+)",
+    "properties": {
+      "direction": 1,
+      "player": {
+        "guild": 2,
+        "name": 3
       },
-      "message":4
+      "message": 4
     }
   },
-  "away":{
-    "regex":"\\[INFO Client [0-9]*] : (DND|AFK) mode is now (?:(ON)\\. Autoreply \"(.*)\"|(OFF))",
-    "function":"evalAway"
+  "away": {
+    "regex": "\\[INFO Client [0-9]*] : (DND|AFK) mode is now (?:(ON)\\. Autoreply \"(.*)\"|(OFF))",
+    "function": "evalAway"
   },
-  "login":{
-    "regex":"\\[INFO Client [0-9]*] Connected to ([a-z]+[0-9]*\\.login\\.pathofexile\\.com) in ([0-9]*)ms\\.",
-    "properties":{
-      "server":1,
-      "latency":2
+  "login": {
+    "regex": "\\[INFO Client [0-9]*] Connected to ([a-z]+[0-9]*\\.login\\.pathofexile\\.com) in ([0-9]*)ms\\.",
+    "properties": {
+      "server": 1,
+      "latency": 2
     }
   },
-  "joinChat":{
-    "regex":"\\[INFO Client [0-9]*] : You have joined ([a-zA-Z0-9]+) chat channel ([0-9]+) ([a-zA-Z0-9]+)\\.",
-    "properties":{
-      "chat":1,
-      "channel":2,
-      "language":3
+  "joinChat": {
+    "regex": "\\[INFO Client [0-9]*] : You have joined ([a-zA-Z0-9]+) chat channel ([0-9]+) ([a-zA-Z0-9]+)\\.",
+    "properties": {
+      "chat": 1,
+      "channel": 2,
+      "language": 3
     }
   },
-  "trade":{
-    "regex":"\\[INFO Client [0-9]*] : Trade (cancelled|accepted)",
-    "function":"evalTrade"
+  "trade": {
+    "regex": "\\[INFO Client [0-9]*] : Trade (cancelled|accepted)",
+    "function": "evalTrade"
   },
-  "deaths":{
-    "regex":"\\[INFO Client [0-9]*] : You have died ([0-9]+) times\\.",
-    "properties":{
-      "deaths":1
+  "deaths": {
+    "regex": "\\[INFO Client [0-9]*] : You have died ([0-9]+) times\\.",
+    "properties": {
+      "deaths": 1
     }
   },
-  "remaining":{
-    "regex":"\\[INFO Client [0-9]*] : (?:More than )?([0-9]+) monsters? remain\\.",
-    "properties":{
-      "monsters":1
+  "remaining": {
+    "regex": "\\[INFO Client [0-9]*] : (?:More than )?([0-9]+) monsters? remain\\.",
+    "properties": {
+      "monsters": 1
     }
   },
-  "death":{
-    "regex":"\\[INFO Client [0-9]*] : (\\S+) has been slain\\.",
-    "properties":{
-      "name":1
+  "death": {
+    "regex": "\\[INFO Client [0-9]*] : (\\S+) has been slain\\.",
+    "properties": {
+      "name": 1
     }
   },
-  "level":{
-    "regex":"\\[INFO Client [0-9]*] : (.*) \\((.*)\\) is now level ([0-9]+)",
-    "properties":{
-      "name":1,
-      "characterClass":2,
-      "level":3
+  "level": {
+    "regex": "\\[INFO Client [0-9]*] : (.*) \\((.*)\\) is now level ([0-9]+)",
+    "properties": {
+      "name": 1,
+      "characterClass": 2,
+      "level": 3
     }
   },
-  "played":{
-    "regex":"\\[INFO Client [0-9]*] : You have played for (?:([0-9]*) days?)?(?:, )?(?:([0-9]*) hours?)?(?:, )?(?:([0-9]*) minutes?)?(?:, )?(?:and )?(?:([0-9]*) seconds?)",
-    "properties":{
-      "days":1,
-      "hours":2,
-      "minutes":3,
-      "seconds":4
+  "played": {
+    "regex": "\\[INFO Client [0-9]*] : You have played for (?:([0-9]*) days?)?(?:, )?(?:([0-9]*) hours?)?(?:, )?(?:([0-9]*) minutes?)?(?:, )?(?:and )?(?:([0-9]*) seconds?)",
+    "properties": {
+      "days": 1,
+      "hours": 2,
+      "minutes": 3,
+      "seconds": 4
     }
   },
-  "age":{
-    "regex":"\\[INFO Client [0-9]*] : Your character was created (?:([0-9]*) days?)?(?:, )?(?:([0-9]*) hours?)?(?:, )?(?:([0-9]*) minutes?)?(?:, )?(?:and )?(?:([0-9]*) seconds?)",
-    "properties":{
-      "days":1,
-      "hours":2,
-      "minutes":3,
-      "seconds":4
+  "age": {
+    "regex": "\\[INFO Client [0-9]*] : Your character was created (?:([0-9]*) days?)?(?:, )?(?:([0-9]*) hours?)?(?:, )?(?:([0-9]*) minutes?)?(?:, )?(?:and )?(?:([0-9]*) seconds?)",
+    "properties": {
+      "days": 1,
+      "hours": 2,
+      "minutes": 3,
+      "seconds": 4
     }
   }
 }


### PR DESCRIPTION
Instance server event can be used to determine if you enter the same area again or a different area, even when the areas have the same name. This is useful for knowing when you finished running a map and not just out for a trade or dumping in stash.

Also added map areas to the resources and normalized so that all areas have an info array. Previously the labyrinth had an object instead. 

Finally i normalized the bosses entry, The area bosses was a object with a name property while the vaal areas only was a string. Now all bosses are a object. 

EDIT: Damn im bad at this, didn't think that all the other commits would join this PR aswell but ifc they did. Closing the other one and sorry for the spam.

Tested and works for me, using this live already in https://github.com/viktorgullmark/exile-party